### PR TITLE
Don't handle subscribe message until we change the API to secure it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -568,27 +568,27 @@ fn process_unblock(from: &Arc<Session>, whom: UserId) -> MessageResult {
     }
 }
 
-fn process_subscribe(from: &Arc<Session>, what: &Subscription) -> MessageResult {
-    janus_info!("Processing subscription from {:p}: {:?}", from.handle, what);
-    if let Err(_existing) = from.subscription.set(what.clone()) {
-        return Err(From::from("Users may only subscribe once!"));
-    }
+// fn process_subscribe(from: &Arc<Session>, what: &Subscription) -> MessageResult {
+//     janus_info!("Processing subscription from {:p}: {:?}", from.handle, what);
+//     if let Err(_existing) = from.subscription.set(what.clone()) {
+//         return Err(From::from("Users may only subscribe once!"));
+//     }
 
-    let mut switchboard = SWITCHBOARD.write()?;
-    if let Some(ref publisher_id) = what.media {
-        let publisher = switchboard
-            .get_publisher(publisher_id)
-            .ok_or("Can't subscribe to a nonexistent publisher.")?
-            .clone();
-        let jsep = json!({
-            "type": "offer",
-            "sdp": publisher.subscriber_offer.lock().unwrap().as_ref().unwrap()
-        });
-        switchboard.subscribe_to_user(from.clone(), publisher);
-        return Ok(MessageResponse::new(json!({}), jsep));
-    }
-    Ok(MessageResponse::msg(json!({})))
-}
+//     let mut switchboard = SWITCHBOARD.write()?;
+//     if let Some(ref publisher_id) = what.media {
+//         let publisher = switchboard
+//             .get_publisher(publisher_id)
+//             .ok_or("Can't subscribe to a nonexistent publisher.")?
+//             .clone();
+//         let jsep = json!({
+//             "type": "offer",
+//             "sdp": publisher.subscriber_offer.lock().unwrap().as_ref().unwrap()
+//         });
+//         switchboard.subscribe_to_user(from.clone(), publisher);
+//         return Ok(MessageResponse::new(json!({}), jsep));
+//     }
+//     Ok(MessageResponse::msg(json!({})))
+// }
 
 fn process_data(from: &Arc<Session>, whom: Option<UserId>, body: &str) -> MessageResult {
     janus_huge!("Processing data message from {:p}: {:?}", from.handle, body);
@@ -616,7 +616,9 @@ fn process_message(from: &Arc<Session>, msg: MessageKind) -> MessageResult {
             token,
         } => process_join(from, room_id, user_id, subscribe, token),
         MessageKind::Kick { room_id, user_id, token } => process_kick(from, room_id, user_id, token),
-        MessageKind::Subscribe { what } => process_subscribe(from, &what),
+        // process_subscribe doesn't check the JWT, we need to change the API to add room_id and token,
+        // comment it for now.
+        // MessageKind::Subscribe { what } => process_subscribe(from, &what),
         MessageKind::Block { whom } => process_block(from, whom),
         MessageKind::Unblock { whom } => process_unblock(from, whom),
         MessageKind::Data { whom, body } => process_data(from, whom, &body),

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -71,7 +71,7 @@ pub enum MessageKind {
     Kick { room_id: RoomId, user_id: UserId, token: String },
 
     /// Indicates that a client wishes to subscribe to traffic described by the given subscription specification.
-    Subscribe { what: Subscription },
+    // Subscribe { what: Subscription },
 
     /// Indicates that a given user should be blocked from receiving your traffic, and that you should not
     /// receive their traffic (superseding any subscriptions you have.)
@@ -163,20 +163,20 @@ mod tests {
             );
         }
 
-        #[test]
-        fn parse_subscribe() {
-            let json = r#"{"kind": "subscribe", "what": {"notifications": false, "data": true, "media": "steve"}}"#;
-            let result: MessageKind = serde_json::from_str(json).unwrap();
-            assert_eq!(
-                result,
-                MessageKind::Subscribe {
-                    what: Subscription {
-                        notifications: false,
-                        data: true,
-                        media: Some("steve".into())
-                    }
-                }
-            );
-        }
+        // #[test]
+        // fn parse_subscribe() {
+        //     let json = r#"{"kind": "subscribe", "what": {"notifications": false, "data": true, "media": "steve"}}"#;
+        //     let result: MessageKind = serde_json::from_str(json).unwrap();
+        //     assert_eq!(
+        //         result,
+        //         MessageKind::Subscribe {
+        //             what: Subscription {
+        //                 notifications: false,
+        //                 data: true,
+        //                 media: Some("steve".into())
+        //             }
+        //         }
+        //     );
+        // }
     }
 }


### PR DESCRIPTION
Don't handle subscribe message until we change the API to secure it with JWT.
This API is not used currently by naf-janus-adapter, but this can still be used for eavesdropping if the UserId of a participant in a room can be easily known (not a random clientId), see my example https://github.com/mozilla/janus-plugin-sfu/pull/81#issuecomment-822468168

This is a temporary PR for those using JWT to secure their rooms. I won't merge this.
I'll close this PR once I work on:

- https://github.com/mozilla/janus-plugin-sfu/issues/83
- https://github.com/mozilla/janus-plugin-sfu/pull/86