### PR TITLE
Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,95 @@
+FROM ubuntu:20.04
+
+RUN apt-get -y update && DEBIAN_FRONTEND="noninteractive" TZ="Europe/Paris" apt-get -y upgrade
+RUN apt-get -y update && DEBIAN_FRONTEND="noninteractive" TZ="Europe/Paris" apt-get install -y libmicrohttpd-dev \
+    libjansson-dev \
+    libssl-dev \
+    libglib2.0-dev \
+    libopus-dev \
+    libogg-dev \
+    libconfig-dev \
+    libssl-dev \
+    pkg-config \
+    gengetopt \
+    libtool \
+    automake \
+    build-essential \
+    subversion \
+    git \
+    cmake \
+    unzip \
+    zip \
+    cargo \
+    wget \
+    curl \
+    iproute2
+
+
+RUN LIBWEBSOCKET="3.2.3" && wget https://github.com/warmcat/libwebsockets/archive/v$LIBWEBSOCKET.tar.gz && \
+    tar xzvf v$LIBWEBSOCKET.tar.gz && \
+    cd libwebsockets-$LIBWEBSOCKET && \
+    mkdir build && \
+    cd build && \
+    cmake -DLWS_MAX_SMP=1 -DLWS_WITHOUT_EXTENSIONS=0 -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_C_FLAGS="-fpic" .. && \
+    make && make install && \
+    cd / && rm -rf libwebsockets-$LIBWEBSOCKET
+
+
+RUN SRTP="2.3.0" && wget https://github.com/cisco/libsrtp/archive/v$SRTP.tar.gz && \
+    tar xfv v$SRTP.tar.gz && \
+    cd libsrtp-$SRTP && \
+    ./configure --prefix=/usr --enable-openssl && \
+    make shared_library && make install && \
+    cd / && rm -rf libsrtp-$SRTP
+
+
+# libnice 2021-02-21 11:10 (post 0.1.18)
+RUN apt-get -y --no-install-recommends install ninja-build meson && \
+    apt-get remove -y libnice-dev libnice10 && \
+    apt-get install -y gtk-doc-tools libgnutls28-dev && \
+    git clone https://gitlab.freedesktop.org/libnice/libnice && \
+    cd libnice && \
+    git checkout 36aa468c4916cfccd4363f0e27af19f2aeae8604 && \
+    meson --prefix=/usr build && \
+    ninja -C build && \
+    ninja -C build install && \
+    cd / && rm -rf libnice
+
+
+# datachannel build
+# Jan 13, 2021 0.9.5.0 07f871bda23943c43c9e74cc54f25130459de830
+RUN git clone https://github.com/sctplab/usrsctp.git && \
+    cd usrsctp && \
+    git checkout 0.9.5.0 && \
+    ./bootstrap && \
+    ./configure --prefix=/usr --disable-programs --disable-inet --disable-inet6 && \
+    make && make install && \
+    cd / && rm -rf usrsctp
+
+
+# 2022-02-18 15:38 24ec58f4e9b16557f27b15b7a6afa23abbf39c45 (post v0.11.8 from 0.x branch)
+RUN git clone -b 0.x https://github.com/meetecho/janus-gateway.git && \
+    cd janus-gateway && \
+    git checkout 24ec58f4e9b16557f27b15b7a6afa23abbf39c45 && \
+    sh autogen.sh &&  \
+    CFLAGS="${CFLAGS} -fno-omit-frame-pointer" ./configure --prefix=/usr --disable-all-plugins --disable-all-handlers && \
+    make && make install && make configs && \
+    cd / && rm -rf janus-gateway
+
+
+RUN git clone -b disable-subscribe-message https://github.com/networked-aframe/janus-plugin-sfu.git && \
+    cd janus-plugin-sfu && \
+    echo version 2 increment this line to invalidate cache of this layer while iterating build during development && \
+    cargo build --release && \
+    mkdir -p /usr/lib/janus/plugins && \
+    mkdir -p /usr/lib/janus/events && \
+    cp target/release/libjanus_plugin_sfu.so /usr/lib/janus/plugins && \
+    cd / && rm -rf janus-plugin-sfu ~/.cargo
+
+COPY confs/* /usr/etc/janus/
+RUN chown -R nobody:nogroup /usr/etc/janus/
+COPY start.sh /start
+
+USER nobody:nogroup
+ENTRYPOINT ["/start"]
+CMD ["janus"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,66 @@
+If you previously installed janus on the host with systemd, stop it and disable it:
+
+```
+systemctl stop janus
+systemctl disable janus
+```
+
+create the docker image:
+
+```
+cd janus-docker
+docker build --pull -t janus:latest .
+```
+
+start the container:
+
+```
+docker run -d --restart always --net=host --name="janus" janus:latest
+```
+
+Be aware that ports 7088 (admin http) and 8188 (ws) are exposed to the host network interface.
+So be sure to configure your instance security group properly to not have access to
+those ports externally and configure traefik or nginx for example in front that
+handle the TLS termination.
+
+Those environment variables with default values are available:
+
+```
+ADMIN_SECRET=janusoverlord
+DEBUG_LEVEL=4
+SESSION_TIMEOUT=38
+MAX_ROOM_SIZE=30
+MAX_CCU=1000
+MESSAGE_THREADS=0
+```
+
+For example to limit rooms to 15 users:
+
+```
+docker run -d --restart always --net=host --name="janus" -e MAX_ROOM_SIZE=15 -e ADMIN_SECRET=YourOwnPassword janus:latest
+```
+
+If you secure the rooms with JWT, specify the public key like this:
+
+```
+-e AUTH_KEY=/keys/public.der -v ./public.der:/keys/public.der:ro
+```
+
+so:
+
+```
+docker run -d --restart always --net=host --name="janus" -e MAX_ROOM_SIZE=15 -e ADMIN_SECRET=YourOwnPassword -e AUTH_KEY=/keys/public.der -v ./public.der:/keys/public.der:ro janus:latest
+```
+
+look at the logs:
+
+```
+docker logs -f janus
+```
+
+stop and remove the container:
+
+```
+docker stop janus
+docker rm janus
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,6 +33,14 @@ cd janus-docker
 docker build --pull -t janus:latest .
 ```
 
+If you previously built the image and want to rebuild with latest janus-plugin-sfu, be sure to increment the
+version in Dockerfile for the janus-plugin-sfu RUN command to invalidate the cache of this layer
+or add `--no-cache` option when building the image:
+
+```
+docker build --pull --no-cache -t janus:latest .
+```
+
 start the container:
 
 ```
@@ -65,6 +73,14 @@ create the docker image:
 ```
 docker-compose build --pull
 ```
+
+or
+
+```
+docker-compose build --pull --no-cache
+```
+
+to rebuild with latest janus-plugin-sfu changes.
 
 configure environment variables in `.env`, example:
 

--- a/docker/confs/janus.jcfg
+++ b/docker/confs/janus.jcfg
@@ -1,0 +1,437 @@
+# General configuration: folders where the configuration and the plugins
+# can be found, how output should be logged, whether Janus should run as
+# a daemon or in foreground, default interface to use, debug/logging level
+# and, if needed, shared apisecret and/or token authentication mechanism
+# between application(s) and Janus.
+general: {
+	configs_folder = "/usr/etc/janus"			# Configuration files folder
+	plugins_folder = "/usr/lib/janus/plugins"			# Plugins folder
+	transports_folder = "/usr/lib/janus/transports"	# Transports folder
+	events_folder = "/usr/lib/janus/events"			# Event handlers folder
+	loggers_folder = "/usr/lib/janus/loggers"			# External loggers folder
+
+		# The next settings configure logging
+	#log_to_stdout = false					# Whether the Janus output should be written
+											# to stdout or not (default=true)
+	#log_to_file = "/path/to/janus.log"		# Whether to use a log file or not
+	debug_level = 4							# Debug/logging level, valid values are 0-7
+	debug_timestamps = true				# Whether to show a timestamp for each log line
+	#debug_colors = false					# Whether colors should be disabled in the log
+	#debug_locks = true						# Whether to enable debugging of locks (very verbose!)
+	#log_prefix = "[janus] "				# In case you want log lines to be prefixed by some
+											# custom text, you can use the 'log_prefix' property.
+											# It supports terminal colors, meaning something like
+											# "[\x1b[32mjanus\x1b[0m] " would show a green "janus"
+											# string in square brackets (assuming debug_colors=true).
+
+		# This is what you configure if you want to launch Janus as a daemon
+	#daemonize = true						# Whether Janus should run as a daemon
+											# or not (default=run in foreground)
+	#pid_file = "/path/to/janus.pid"		# PID file to create when Janus has been
+											# started, and to destroy at shutdown
+
+		# There are different ways you can authenticate the Janus and Admin APIs
+	#api_secret = "janusrocks"		# String that all Janus requests must contain
+									# to be accepted/authorized by the Janus core.
+									# Useful if you're wrapping all Janus API requests
+									# in your servers (that is, not in the browser,
+									# where you do the things your way) and you
+									# don't want other application to mess with
+									# this Janus instance.
+	#token_auth = true				# Enable a token based authentication
+									# mechanism to force users to always provide
+									# a valid token in all requests. Useful if
+									# you want to authenticate requests from web
+									# users.
+	#token_auth_secret = "janus"	# Use HMAC-SHA1 signed tokens (with token_auth). Note that
+									# without this, the Admin API MUST
+									# be enabled, as tokens are added and removed
+									# through messages sent there.
+	admin_secret = "janusoverlord"	# String that all Janus requests must contain
+									# to be accepted/authorized by the admin/monitor.
+									# only needed if you enabled the admin API
+									# in any of the available transports.
+
+		# Generic settings
+	#interface = "1.2.3.4"			# Interface to use (will be used in SDP)
+	server_name = "janus" # Public name of this Janus instance
+									# as it will appear in an info request
+	#session_timeout = 60			# How long (in seconds) we should wait before
+									# deciding a Janus session has timed out. A
+									# session times out when no request is received
+									# for session_timeout seconds (default=60s).
+									# Setting this to 0 will disable the timeout
+									# mechanism, which is NOT suggested as it may
+									# risk having orphaned sessions (sessions not
+									# controlled by any transport and never freed).
+									# To avoid timeouts, keep-alives can be used.
+	#candidates_timeout = 45		# How long (in seconds) we should keep hold of
+									# pending (trickle) candidates before discarding
+									# them (default=45s). Notice that setting this
+									# to 0 will NOT disable the timeout, but will
+									# be considered an invalid value and ignored.
+	#reclaim_session_timeout = 0	# How long (in seconds) we should wait for a
+									# janus session to be reclaimed after the transport
+									# is gone. After the transport is gone, a session
+									# times out when no request is received for
+									# reclaim_session_timeout seconds (default=0s).
+									# Setting this to 0 will disable the timeout
+									# mechanism, and sessions will be destroyed immediately
+									# if the transport is gone.
+	#recordings_tmp_ext = "tmp"		# The extension for recordings, in Janus, is
+									# .mjr, a custom format we devised ourselves.
+									# By default, we save to .mjr directly. If you'd
+									# rather the recording filename have a temporary
+									# extension while it's being saved, and only
+									# have the .mjr extension when the recording
+									# is over (e.g., to automatically trigger some
+									# external scripts), then uncomment and set the
+									# recordings_tmp_ext property to the extension
+									# to add to the base (e.g., tmp --> .mjr.tmp).
+	#event_loops = 8				# By default, Janus handles each have their own
+									# event loop and related thread for all the media
+									# routing and management. If for some reason you'd
+									# rather limit the number of loop/threads, and
+									# you want handles to share those, you can do that
+									# configuring the event_loops property: this will
+									# spawn the specified amount of threads at startup,
+									# run a separate event loop on each of them, and
+									# add new handles to one of them when attaching.
+									# Notice that, while cutting the number of threads
+									# and possibly reducing context switching, this
+									# might have an impact on the media delivery,
+									# especially if the available loops can't take
+									# care of all the handles and their media in time.
+									# As such, if you want to use this you should
+									# provision the correct value according to the
+									# available resources (e.g., CPUs available).
+	#allow_loop_indication = true	# In case a static number of event loops is
+									# configured as explained above, by default
+									# new handles will be allocated on one loop or
+									# another by the Janus core itself. In some cases
+									# it may be helpful to manually tell the Janus
+									# core which loop a handle should be added to,
+									# e.g., to group viewers of the same stream on
+									# the same loop. This is possible via the Janus
+									# API when performing the 'attach' request, but
+									# only if allow_loop_indication is set to true;
+									# it's set to false by default to avoid abuses.
+									# Don't change if you don't know what you're doing!
+	#opaqueid_in_api = true			# Opaque IDs set by applications are typically
+									# only passed to event handlers for correlation
+									# purposes, but not sent back to the user or
+									# application in the related Janus API responses
+									# or events; in case you need them to be in the
+									# Janus API too, set this property to 'true'.
+	#hide_dependencies = true		# By default, a call to the "info" endpoint of
+									# either the Janus or Admin API now also returns
+									# the versions of the main dependencies (e.g.,
+									# libnice, libsrtp, which crypto library is in
+									# use and so on). Should you want that info not
+									# to be disclose, set 'hide_dependencies' to true.
+	#exit_on_dl_error = false		# If a Janus shared libary cannot be loaded or an expected
+									# symbol is not found, exit immediately.
+
+		# The following is ONLY useful when debugging RTP/RTCP packets,
+		# e.g., to look at unencrypted live traffic with a browser. By
+		# default it is obviously disabled, as WebRTC mandates encryption.
+	#no_webrtc_encryption = true
+
+		# Janus provides ways via its API to specify custom paths to save
+		# files to (e.g., recordings, pcap captures and the like). In order
+		# to avoid people can mess with folders they're not supposed to,
+		# you can configure an array of folders that Janus should prevent
+		# creating files in. If the 'protected_folder' property below is
+		# commented, no folder is protected.
+		# Notice that at the moment this only covers attempts to start
+		# an .mjr recording and pcap/text2pcap packet captures.
+	protected_folders = [
+		"/bin",
+		"/boot",
+		"/dev",
+		"/etc",
+		"/initrd",
+		"/lib",
+		"/lib32",
+		"/lib64",
+		"/proc",
+		"/sbin",
+		"/sys",
+		"/usr",
+		"/var",
+			# We add what are usually the folders Janus is installed to
+			# as well: we don't just put "/opt/janus" because that would
+			# include folders like "/opt/janus/share" that is where
+			# recordings might be saved to by some plugins
+		"/opt/janus/bin",
+		"/opt/janus/etc",
+		"/opt/janus/include",
+		"/opt/janus/lib",
+		"/opt/janus/lib32",
+		"/opt/janus/lib64",
+		"/opt/janus/sbin"
+	]
+}
+
+# Certificate and key to use for DTLS (and passphrase if needed). If missing,
+# Janus will autogenerate a self-signed certificate to use. Notice that
+# self-signed certificates are fine for the purpose of WebRTC DTLS
+# connectivity, for the time being, at least until Identity Providers
+# are standardized and implemented in browsers. If for some reason you
+# want to enforce the DTLS stack in Janus to enforce valid certificates
+# from peers, though, you can do that setting 'dtls_accept_selfsigned' to
+# 'false' below: DO NOT TOUCH THAT IF YOU DO NOT KNOW WHAT YOU'RE DOING!
+# You can also configure the DTLS ciphers to offer: the default if not
+# set is "DEFAULT:!NULL:!aNULL:!SHA256:!SHA384:!aECDH:!AESGCM+AES256:!aPSK"
+# Finally, by default NIST P-256 certificates are generated (see #1997),
+# but RSA generation is still supported if you set 'rsa_private_key' to 'true'.
+certificates: {
+	#cert_pem = "/path/to/certificate.pem"
+	#cert_key = "/path/to/key.pem"
+	#cert_pwd = "secretpassphrase"
+	#dtls_accept_selfsigned = false
+	#dtls_ciphers = "your-desired-openssl-ciphers"
+	#rsa_private_key = false
+}
+
+# Media-related stuff: you can configure whether if you want to enable IPv6
+# support (and link-local IPs), the minimum size of the NACK queue (in ms,
+# defaults to 200ms) for retransmissions no matter the RTT, the range of
+# ports to use for RTP and RTCP (by default, no range is envisaged), the
+# starting MTU for DTLS (1200 by default, it adapts automatically),
+# how much time, in seconds, should pass with no media (audio or
+# video) being received before Janus notifies you about this (default=1s,
+# 0 disables these events entirely), how many lost packets should trigger a
+# 'slowlink' event to users (default=0, disabled), and how often, in milliseconds,
+# to send the Transport Wide Congestion Control feedback information back
+# to senders, if negotiated (default=200ms). Finally, if you're using BoringSSL
+# you can customize the frequency of retransmissions: OpenSSL has a fixed
+# value of 1 second (the default), while BoringSSL can override that. Notice
+# that lower values (e.g., 100ms) will typically get you faster connection
+# times, but may not work in case the RTT of the user is high: as such,
+# you should pick a reasonable trade-off (usually 2*max expected RTT).
+media: {
+	#ipv6 = true
+	#ipv6_linklocal = true
+	#min_nack_queue = 500
+	rtp_port_range = "51610-65535"
+	#dtls_mtu = 1200
+	#no_media_timer = 1
+	slowlink_threshold = 4
+	#twcc_period = 100
+	#dtls_timeout = 500
+
+	# Janus can do some optimizations on the NACK queue, specifically when
+	# keyframes are involved. Namely, you can configure Janus so that any
+	# time a keyframe is sent to a user, the NACK buffer for that connection
+	# is emptied. This allows Janus to ignore NACK requests for packets
+	# sent shortly before the keyframe was sent, since it can be assumed
+	# that the keyframe will restore a complete working image for the user
+	# anyway (which is the main reason why video retransmissions are typically
+	# required). While this optimization is known to work fine in most cases,
+	# it can backfire in some edge cases, and so is disabled by default.
+	#nack_optimizations = true
+
+	# If you need DSCP packet marking and prioritization, you can configure
+	# the 'dscp' property to a specific values, and Janus will try to
+	# set it on all outgoing packets using libnice. Normally, the specs
+	# suggest to use different values depending on whether audio, video
+	# or data are used, but since all PeerConnections in Janus are bundled,
+	# we can only use one. You can refer to this document for more info:
+	# https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos-18#page-6
+	# That said, DON'T TOUCH THIS IF YOU DON'T KNOW WHAT IT MEANS!
+	#dscp = 46
+}
+
+# NAT-related stuff: specifically, you can configure the STUN/TURN
+# servers to use to gather candidates if the gateway is behind a NAT,
+# and srflx/relay candidates are needed. In case STUN is not enough and
+# this is needed (it shouldn't), you can also configure Janus to use a
+# TURN server# please notice that this does NOT refer to TURN usage in
+# browsers, but in the gathering of relay candidates by Janus itself,
+# e.g., if you want to limit the ports used by a Janus instance on a
+# private machine. Furthermore, you can choose whether Janus should be
+# configured to do full-trickle (Janus also trickles its candidates to
+# users) rather than the default half-trickle (Janus supports trickle
+# candidates from users, but sends its own within the SDP), and whether
+# it should work in ICE-Lite mode (by default it doesn't). If libnice is
+# at least 0.1.15, you can choose which ICE nomination mode to use: valid
+# values are "regular" and "aggressive" (the default depends on the libnice
+# version itself; if we can set it, we set aggressive nomination). You can
+# also configure whether to use connectivity checks as keep-alives, which
+# might help detecting when a peer is no longer available (notice that
+# current libnice master is breaking connections after 50 seconds when
+# keepalive-conncheck is being used, so if you want to use it, better
+# sticking to 0.1.18 until the issue is addressed upstream). Finally,
+# you can also enable ICE-TCP support (beware that this may lead to problems
+# if you do not enable ICE Lite as well), choose which interfaces should
+# be used for gathering candidates, and enable or disable the
+# internal libnice debugging, if needed.
+nat: {
+	#stun_server = "stun.voip.eutelia.it"
+	#stun_port = 3478
+	nice_debug = false
+	#full_trickle = true
+	ice_nomination = "aggressive"
+	ice_keepalive_conncheck = false
+	ice_lite = false
+	ice_tcp = false
+
+	# By default Janus tries to resolve mDNS (.local) candidates: even
+	# though this is now done asynchronously and shouldn't keep the API
+	# busy, even in case mDNS resolution takes a long time to timeout,
+	# you can choose to drop all .local candidates instead, which is
+	# helpful in case you know clients will never be in the same private
+	# network as the one the Janus instance is running from. Notice that
+	# this will cause ICE to fail if mDNS is the only way to connect!
+	ignore_mdns = true
+
+	# In case you're deploying Janus on a server which is configured with
+	# a 1:1 NAT (e.g., Amazon EC2), you might want to also specify the public
+	# address of the machine using the setting below. This will result in
+	# all host candidates (which normally have a private IP address) to
+	# be rewritten with the public address provided in the settings. As
+	# such, use the option with caution and only if you know what you're doing.
+	# Make sure you keep ICE Lite disabled, though, as it's not strictly
+	# speaking a publicly reachable server, and a NAT is still involved.
+	# If you'd rather keep the private IP address in place, rather than
+	# replacing it (and so have both of them as advertised candidates),
+	# then set the 'keep_private_host' property to true.
+	# Multiple public IP addresses can be specified as a comma separated list
+	# if the Janus is deployed in a DMZ between two 1-1 NAT for internal and
+	# external users.
+	#nat_1_1_mapping = "1.2.3.4"
+	#keep_private_host = true
+
+	# You can configure a TURN server in two different ways: specifying a
+	# statically configured TURN server, and thus provide the address of the
+	# TURN server, the transport (udp/tcp/tls) to use, and a set of valid
+	# credentials to authenticate. Notice that you should NEVER configure
+	# a TURN server for Janus unless it's really what you want! If you want
+	# *users* to use TURN, then you need to configure that on the client
+	# side, and NOT in Janus. The following TURN configuration should ONLY
+	# be enabled when Janus itself is sitting behind a restrictive firewall
+	# (e.g., it's part of a service installed on a box in a private home).
+	#turn_server = "myturnserver.com"
+	#turn_port = 3478
+	#turn_type = "udp"
+	#turn_user = "myuser"
+	#turn_pwd = "mypassword"
+
+	# You can also make use of the TURN REST API to get info on one or more
+	# TURN services dynamically. This makes use of the proposed standard of
+	# such an API (https://tools.ietf.org/html/draft-uberti-behave-turn-rest-00)
+	# which is currently available in both rfc5766-turn-server and coturn.
+	# You enable this by specifying the address of your TURN REST API backend,
+	# the HTTP method to use (GET or POST) and, if required, the API key Janus
+	# must provide. The timeout can be configured in seconds, with a default of
+	# 10 seconds and a minimum of 1 second. Notice that the 'opaque_id' provided
+	# via Janus API will be used as the username for a specific PeerConnection
+	# by default; if that one is missing, the 'session_id' will be used as the
+	# username instead.
+	#turn_rest_api = "http://yourbackend.com/path/to/api"
+	#turn_rest_api_key = "anyapikeyyoumayhaveset"
+	#turn_rest_api_method = "GET"
+	#turn_rest_api_timeout = 10
+
+	# In case a TURN server is provided, you can allow applications to force
+	# Janus to use TURN (https://github.com/meetecho/janus-gateway/pull/2774).
+	# This is NOT allowed by default: only enable it if you know what you're doing.
+	#allow_force_relay = true
+
+	# You can also choose which interfaces should be explicitly used by the
+	# gateway for the purpose of ICE candidates gathering, thus excluding
+	# others that may be available. To do so, use the 'ice_enforce_list'
+	# setting and pass it a comma-separated list of interfaces or IP addresses
+	# to enforce. This is especially useful if the server hosting the gateway
+	# has several interfaces, and you only want a subset to be used. Any of
+	# the following examples are valid:
+	#     ice_enforce_list = "eth0"
+	#     ice_enforce_list = "eth0,eth1"
+	#     ice_enforce_list = "eth0,192.168."
+	#     ice_enforce_list = "eth0,192.168.0.1"
+	# By default, no interface is enforced, meaning Janus will try to use them all.
+	#ice_enforce_list = "eth0"
+
+	# In case you don't want to specify specific interfaces to use, but would
+	# rather tell Janus to use all the available interfaces except some that
+	# you don't want to involve, you can also choose which interfaces or IP
+	# addresses should be excluded and ignored by the gateway for the purpose
+	# of ICE candidates gathering. To do so, use the 'ice_ignore_list' setting
+	# and pass it a comma-separated list of interfaces or IP addresses to
+	# ignore. This is especially useful if the server hosting the gateway
+	# has several interfaces you already know will not be used or will simply
+	# always slow down ICE (e.g., virtual interfaces created by VMware).
+	# Partial strings are supported, which means that any of the following
+	# examples are valid:
+	#     ice_ignore_list = "vmnet8,192.168.0.1,10.0.0.1"
+	#     ice_ignore_list = "vmnet,192.168."
+	# Just beware that the ICE ignore list is not used if an enforce list
+	# has been configured. By default, Janus ignores all interfaces whose
+	# name starts with 'vmnet', to skip VMware interfaces:
+	ice_ignore_list = "vmnet"
+
+	# In case you want to allow Janus to start even if the configured STUN or TURN
+	# server is unreachable, you can set 'ignore_unreachable_ice_server' to true.
+	# WARNING: We do not recommend to ignore reachability problems, particularly
+	# if you run Janus in the cloud. Before enabling this flag, make sure your
+	# system is correctly configured and Janus starts after the network layer of
+	# your machine is ready. Note that Linux distributions offer such directives.
+	# You could use the following directive in systemd: 'After=network-online.target'
+	# https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Before=
+	#ignore_unreachable_ice_server = true
+}
+
+# You can choose which of the available plugins should be
+# enabled or not. Use the 'disable' directive to prevent Janus from
+# loading one or more plugins: use a comma separated list of plugin file
+# names to identify the plugins to disable. By default all available
+# plugins are enabled and loaded at startup.
+plugins: {
+	#disable = "libjanus_voicemail.so,libjanus_recordplay.so"
+}
+
+# You can choose which of the available transports should be enabled or
+# not. Use the 'disable' directive to prevent Janus from loading one
+# or more transport: use a comma separated list of transport file names
+# to identify the transports to disable. By default all available
+# transports are enabled and loaded at startup.
+transports: {
+	disable = "libjanus_pfunix.so"
+}
+
+# As a core feature, Janus can log either on the standard output, or to
+# a local file. Should you need more advanced logging functionality, you
+# can make use of one of the custom loggers, or write one yourself. Use the
+# 'disable' directive to prevent Janus from loading one or more loggers:
+# use a comma separated list of logger file names to identify the loggers
+# to disable. By default all available loggers are enabled and loaded at startup.
+loggers: {
+	#disable = "libjanus_jsonlog.so"
+}
+
+# Event handlers allow you to receive live events from Janus happening
+# in core and/or plugins. Since this can require some more resources,
+# the feature is disabled by default. Setting broadcast to yes will
+# enable them. You can then choose which of the available event handlers
+# should be loaded or not. Use the 'disable' directive to prevent Janus
+# from loading one or more event handlers: use a comma separated list of
+# file names to identify the event handlers to disable. By default, if
+# broadcast is set to yes all available event handlers are enabled and
+# loaded at startup. Finally, you can choose how often media statistics
+# (packets sent/received, losses, etc.) should be sent: by default it's
+# once per second (audio and video statistics sent separately), but may
+# considered too verbose, or you may want to limit the number of events,
+# especially if you have many PeerConnections active. To change this,
+# just set 'stats_period' to the number of seconds that should pass in
+# between statistics for each handle. Setting it to 0 disables them (but
+# not other media-related events). By default Janus sends single media
+# statistic events per media (audio, video and simulcast layers as separate
+# events): if you'd rather receive a single containing all media stats in a
+# single array, set 'combine_media_stats' to true.
+events: {
+	broadcast = true
+	#combine_media_stats = true
+	#disable = "libjanus_sampleevh.so"
+	stats_period = 5
+}

--- a/docker/confs/janus.jcfg.sample
+++ b/docker/confs/janus.jcfg.sample
@@ -1,0 +1,437 @@
+# General configuration: folders where the configuration and the plugins
+# can be found, how output should be logged, whether Janus should run as
+# a daemon or in foreground, default interface to use, debug/logging level
+# and, if needed, shared apisecret and/or token authentication mechanism
+# between application(s) and Janus.
+general: {
+	configs_folder = "/usr/etc/janus"			# Configuration files folder
+	plugins_folder = "/usr/lib/janus/plugins"			# Plugins folder
+	transports_folder = "/usr/lib/janus/transports"	# Transports folder
+	events_folder = "/usr/lib/janus/events"			# Event handlers folder
+	loggers_folder = "/usr/lib/janus/loggers"			# External loggers folder
+
+		# The next settings configure logging
+	#log_to_stdout = false					# Whether the Janus output should be written
+											# to stdout or not (default=true)
+	#log_to_file = "/path/to/janus.log"		# Whether to use a log file or not
+	debug_level = 4							# Debug/logging level, valid values are 0-7
+	#debug_timestamps = true				# Whether to show a timestamp for each log line
+	#debug_colors = false					# Whether colors should be disabled in the log
+	#debug_locks = true						# Whether to enable debugging of locks (very verbose!)
+	#log_prefix = "[janus] "				# In case you want log lines to be prefixed by some
+											# custom text, you can use the 'log_prefix' property.
+											# It supports terminal colors, meaning something like
+											# "[\x1b[32mjanus\x1b[0m] " would show a green "janus"
+											# string in square brackets (assuming debug_colors=true).
+
+		# This is what you configure if you want to launch Janus as a daemon
+	#daemonize = true						# Whether Janus should run as a daemon
+											# or not (default=run in foreground)
+	#pid_file = "/path/to/janus.pid"		# PID file to create when Janus has been
+											# started, and to destroy at shutdown
+
+		# There are different ways you can authenticate the Janus and Admin APIs
+	#api_secret = "janusrocks"		# String that all Janus requests must contain
+									# to be accepted/authorized by the Janus core.
+									# Useful if you're wrapping all Janus API requests
+									# in your servers (that is, not in the browser,
+									# where you do the things your way) and you
+									# don't want other application to mess with
+									# this Janus instance.
+	#token_auth = true				# Enable a token based authentication
+									# mechanism to force users to always provide
+									# a valid token in all requests. Useful if
+									# you want to authenticate requests from web
+									# users.
+	#token_auth_secret = "janus"	# Use HMAC-SHA1 signed tokens (with token_auth). Note that
+									# without this, the Admin API MUST
+									# be enabled, as tokens are added and removed
+									# through messages sent there.
+	admin_secret = "janusoverlord"	# String that all Janus requests must contain
+									# to be accepted/authorized by the admin/monitor.
+									# only needed if you enabled the admin API
+									# in any of the available transports.
+
+		# Generic settings
+	#interface = "1.2.3.4"			# Interface to use (will be used in SDP)
+	#server_name = "MyJanusInstance"# Public name of this Janus instance
+									# as it will appear in an info request
+	#session_timeout = 60			# How long (in seconds) we should wait before
+									# deciding a Janus session has timed out. A
+									# session times out when no request is received
+									# for session_timeout seconds (default=60s).
+									# Setting this to 0 will disable the timeout
+									# mechanism, which is NOT suggested as it may
+									# risk having orphaned sessions (sessions not
+									# controlled by any transport and never freed).
+									# To avoid timeouts, keep-alives can be used.
+	#candidates_timeout = 45		# How long (in seconds) we should keep hold of
+									# pending (trickle) candidates before discarding
+									# them (default=45s). Notice that setting this
+									# to 0 will NOT disable the timeout, but will
+									# be considered an invalid value and ignored.
+	#reclaim_session_timeout = 0	# How long (in seconds) we should wait for a
+									# janus session to be reclaimed after the transport
+									# is gone. After the transport is gone, a session
+									# times out when no request is received for
+									# reclaim_session_timeout seconds (default=0s).
+									# Setting this to 0 will disable the timeout
+									# mechanism, and sessions will be destroyed immediately
+									# if the transport is gone.
+	#recordings_tmp_ext = "tmp"		# The extension for recordings, in Janus, is
+									# .mjr, a custom format we devised ourselves.
+									# By default, we save to .mjr directly. If you'd
+									# rather the recording filename have a temporary
+									# extension while it's being saved, and only
+									# have the .mjr extension when the recording
+									# is over (e.g., to automatically trigger some
+									# external scripts), then uncomment and set the
+									# recordings_tmp_ext property to the extension
+									# to add to the base (e.g., tmp --> .mjr.tmp).
+	#event_loops = 8				# By default, Janus handles each have their own
+									# event loop and related thread for all the media
+									# routing and management. If for some reason you'd
+									# rather limit the number of loop/threads, and
+									# you want handles to share those, you can do that
+									# configuring the event_loops property: this will
+									# spawn the specified amount of threads at startup,
+									# run a separate event loop on each of them, and
+									# add new handles to one of them when attaching.
+									# Notice that, while cutting the number of threads
+									# and possibly reducing context switching, this
+									# might have an impact on the media delivery,
+									# especially if the available loops can't take
+									# care of all the handles and their media in time.
+									# As such, if you want to use this you should
+									# provision the correct value according to the
+									# available resources (e.g., CPUs available).
+	#allow_loop_indication = true	# In case a static number of event loops is
+									# configured as explained above, by default
+									# new handles will be allocated on one loop or
+									# another by the Janus core itself. In some cases
+									# it may be helpful to manually tell the Janus
+									# core which loop a handle should be added to,
+									# e.g., to group viewers of the same stream on
+									# the same loop. This is possible via the Janus
+									# API when performing the 'attach' request, but
+									# only if allow_loop_indication is set to true;
+									# it's set to false by default to avoid abuses.
+									# Don't change if you don't know what you're doing!
+	#opaqueid_in_api = true			# Opaque IDs set by applications are typically
+									# only passed to event handlers for correlation
+									# purposes, but not sent back to the user or
+									# application in the related Janus API responses
+									# or events; in case you need them to be in the
+									# Janus API too, set this property to 'true'.
+	#hide_dependencies = true		# By default, a call to the "info" endpoint of
+									# either the Janus or Admin API now also returns
+									# the versions of the main dependencies (e.g.,
+									# libnice, libsrtp, which crypto library is in
+									# use and so on). Should you want that info not
+									# to be disclose, set 'hide_dependencies' to true.
+	#exit_on_dl_error = false		# If a Janus shared libary cannot be loaded or an expected
+									# symbol is not found, exit immediately.
+
+		# The following is ONLY useful when debugging RTP/RTCP packets,
+		# e.g., to look at unencrypted live traffic with a browser. By
+		# default it is obviously disabled, as WebRTC mandates encryption.
+	#no_webrtc_encryption = true
+
+		# Janus provides ways via its API to specify custom paths to save
+		# files to (e.g., recordings, pcap captures and the like). In order
+		# to avoid people can mess with folders they're not supposed to,
+		# you can configure an array of folders that Janus should prevent
+		# creating files in. If the 'protected_folder' property below is
+		# commented, no folder is protected.
+		# Notice that at the moment this only covers attempts to start
+		# an .mjr recording and pcap/text2pcap packet captures.
+	protected_folders = [
+		"/bin",
+		"/boot",
+		"/dev",
+		"/etc",
+		"/initrd",
+		"/lib",
+		"/lib32",
+		"/lib64",
+		"/proc",
+		"/sbin",
+		"/sys",
+		"/usr",
+		"/var",
+			# We add what are usually the folders Janus is installed to
+			# as well: we don't just put "/opt/janus" because that would
+			# include folders like "/opt/janus/share" that is where
+			# recordings might be saved to by some plugins
+		"/opt/janus/bin",
+		"/opt/janus/etc",
+		"/opt/janus/include",
+		"/opt/janus/lib",
+		"/opt/janus/lib32",
+		"/opt/janus/lib64",
+		"/opt/janus/sbin"
+	]
+}
+
+# Certificate and key to use for DTLS (and passphrase if needed). If missing,
+# Janus will autogenerate a self-signed certificate to use. Notice that
+# self-signed certificates are fine for the purpose of WebRTC DTLS
+# connectivity, for the time being, at least until Identity Providers
+# are standardized and implemented in browsers. If for some reason you
+# want to enforce the DTLS stack in Janus to enforce valid certificates
+# from peers, though, you can do that setting 'dtls_accept_selfsigned' to
+# 'false' below: DO NOT TOUCH THAT IF YOU DO NOT KNOW WHAT YOU'RE DOING!
+# You can also configure the DTLS ciphers to offer: the default if not
+# set is "DEFAULT:!NULL:!aNULL:!SHA256:!SHA384:!aECDH:!AESGCM+AES256:!aPSK"
+# Finally, by default NIST P-256 certificates are generated (see #1997),
+# but RSA generation is still supported if you set 'rsa_private_key' to 'true'.
+certificates: {
+	#cert_pem = "/path/to/certificate.pem"
+	#cert_key = "/path/to/key.pem"
+	#cert_pwd = "secretpassphrase"
+	#dtls_accept_selfsigned = false
+	#dtls_ciphers = "your-desired-openssl-ciphers"
+	#rsa_private_key = false
+}
+
+# Media-related stuff: you can configure whether if you want to enable IPv6
+# support (and link-local IPs), the minimum size of the NACK queue (in ms,
+# defaults to 200ms) for retransmissions no matter the RTT, the range of
+# ports to use for RTP and RTCP (by default, no range is envisaged), the
+# starting MTU for DTLS (1200 by default, it adapts automatically),
+# how much time, in seconds, should pass with no media (audio or
+# video) being received before Janus notifies you about this (default=1s,
+# 0 disables these events entirely), how many lost packets should trigger a
+# 'slowlink' event to users (default=0, disabled), and how often, in milliseconds,
+# to send the Transport Wide Congestion Control feedback information back
+# to senders, if negotiated (default=200ms). Finally, if you're using BoringSSL
+# you can customize the frequency of retransmissions: OpenSSL has a fixed
+# value of 1 second (the default), while BoringSSL can override that. Notice
+# that lower values (e.g., 100ms) will typically get you faster connection
+# times, but may not work in case the RTT of the user is high: as such,
+# you should pick a reasonable trade-off (usually 2*max expected RTT).
+media: {
+	#ipv6 = true
+	#ipv6_linklocal = true
+	#min_nack_queue = 500
+	#rtp_port_range = "20000-40000"
+	#dtls_mtu = 1200
+	#no_media_timer = 1
+	#slowlink_threshold = 4
+	#twcc_period = 100
+	#dtls_timeout = 500
+
+	# Janus can do some optimizations on the NACK queue, specifically when
+	# keyframes are involved. Namely, you can configure Janus so that any
+	# time a keyframe is sent to a user, the NACK buffer for that connection
+	# is emptied. This allows Janus to ignore NACK requests for packets
+	# sent shortly before the keyframe was sent, since it can be assumed
+	# that the keyframe will restore a complete working image for the user
+	# anyway (which is the main reason why video retransmissions are typically
+	# required). While this optimization is known to work fine in most cases,
+	# it can backfire in some edge cases, and so is disabled by default.
+	#nack_optimizations = true
+
+	# If you need DSCP packet marking and prioritization, you can configure
+	# the 'dscp' property to a specific values, and Janus will try to
+	# set it on all outgoing packets using libnice. Normally, the specs
+	# suggest to use different values depending on whether audio, video
+	# or data are used, but since all PeerConnections in Janus are bundled,
+	# we can only use one. You can refer to this document for more info:
+	# https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos-18#page-6
+	# That said, DON'T TOUCH THIS IF YOU DON'T KNOW WHAT IT MEANS!
+	#dscp = 46
+}
+
+# NAT-related stuff: specifically, you can configure the STUN/TURN
+# servers to use to gather candidates if the gateway is behind a NAT,
+# and srflx/relay candidates are needed. In case STUN is not enough and
+# this is needed (it shouldn't), you can also configure Janus to use a
+# TURN server# please notice that this does NOT refer to TURN usage in
+# browsers, but in the gathering of relay candidates by Janus itself,
+# e.g., if you want to limit the ports used by a Janus instance on a
+# private machine. Furthermore, you can choose whether Janus should be
+# configured to do full-trickle (Janus also trickles its candidates to
+# users) rather than the default half-trickle (Janus supports trickle
+# candidates from users, but sends its own within the SDP), and whether
+# it should work in ICE-Lite mode (by default it doesn't). If libnice is
+# at least 0.1.15, you can choose which ICE nomination mode to use: valid
+# values are "regular" and "aggressive" (the default depends on the libnice
+# version itself; if we can set it, we set aggressive nomination). You can
+# also configure whether to use connectivity checks as keep-alives, which
+# might help detecting when a peer is no longer available (notice that
+# current libnice master is breaking connections after 50 seconds when
+# keepalive-conncheck is being used, so if you want to use it, better
+# sticking to 0.1.18 until the issue is addressed upstream). Finally,
+# you can also enable ICE-TCP support (beware that this may lead to problems
+# if you do not enable ICE Lite as well), choose which interfaces should
+# be used for gathering candidates, and enable or disable the
+# internal libnice debugging, if needed.
+nat: {
+	#stun_server = "stun.voip.eutelia.it"
+	#stun_port = 3478
+	nice_debug = false
+	#full_trickle = true
+	#ice_nomination = "regular"
+	#ice_keepalive_conncheck = true
+	#ice_lite = true
+	#ice_tcp = true
+
+	# By default Janus tries to resolve mDNS (.local) candidates: even
+	# though this is now done asynchronously and shouldn't keep the API
+	# busy, even in case mDNS resolution takes a long time to timeout,
+	# you can choose to drop all .local candidates instead, which is
+	# helpful in case you know clients will never be in the same private
+	# network as the one the Janus instance is running from. Notice that
+	# this will cause ICE to fail if mDNS is the only way to connect!
+	#ignore_mdns = true
+
+	# In case you're deploying Janus on a server which is configured with
+	# a 1:1 NAT (e.g., Amazon EC2), you might want to also specify the public
+	# address of the machine using the setting below. This will result in
+	# all host candidates (which normally have a private IP address) to
+	# be rewritten with the public address provided in the settings. As
+	# such, use the option with caution and only if you know what you're doing.
+	# Make sure you keep ICE Lite disabled, though, as it's not strictly
+	# speaking a publicly reachable server, and a NAT is still involved.
+	# If you'd rather keep the private IP address in place, rather than
+	# replacing it (and so have both of them as advertised candidates),
+	# then set the 'keep_private_host' property to true.
+	# Multiple public IP addresses can be specified as a comma separated list
+	# if the Janus is deployed in a DMZ between two 1-1 NAT for internal and
+	# external users.
+	#nat_1_1_mapping = "1.2.3.4"
+	#keep_private_host = true
+
+	# You can configure a TURN server in two different ways: specifying a
+	# statically configured TURN server, and thus provide the address of the
+	# TURN server, the transport (udp/tcp/tls) to use, and a set of valid
+	# credentials to authenticate. Notice that you should NEVER configure
+	# a TURN server for Janus unless it's really what you want! If you want
+	# *users* to use TURN, then you need to configure that on the client
+	# side, and NOT in Janus. The following TURN configuration should ONLY
+	# be enabled when Janus itself is sitting behind a restrictive firewall
+	# (e.g., it's part of a service installed on a box in a private home).
+	#turn_server = "myturnserver.com"
+	#turn_port = 3478
+	#turn_type = "udp"
+	#turn_user = "myuser"
+	#turn_pwd = "mypassword"
+
+	# You can also make use of the TURN REST API to get info on one or more
+	# TURN services dynamically. This makes use of the proposed standard of
+	# such an API (https://tools.ietf.org/html/draft-uberti-behave-turn-rest-00)
+	# which is currently available in both rfc5766-turn-server and coturn.
+	# You enable this by specifying the address of your TURN REST API backend,
+	# the HTTP method to use (GET or POST) and, if required, the API key Janus
+	# must provide. The timeout can be configured in seconds, with a default of
+	# 10 seconds and a minimum of 1 second. Notice that the 'opaque_id' provided
+	# via Janus API will be used as the username for a specific PeerConnection
+	# by default; if that one is missing, the 'session_id' will be used as the
+	# username instead.
+	#turn_rest_api = "http://yourbackend.com/path/to/api"
+	#turn_rest_api_key = "anyapikeyyoumayhaveset"
+	#turn_rest_api_method = "GET"
+	#turn_rest_api_timeout = 10
+
+	# In case a TURN server is provided, you can allow applications to force
+	# Janus to use TURN (https://github.com/meetecho/janus-gateway/pull/2774).
+	# This is NOT allowed by default: only enable it if you know what you're doing.
+	#allow_force_relay = true
+
+	# You can also choose which interfaces should be explicitly used by the
+	# gateway for the purpose of ICE candidates gathering, thus excluding
+	# others that may be available. To do so, use the 'ice_enforce_list'
+	# setting and pass it a comma-separated list of interfaces or IP addresses
+	# to enforce. This is especially useful if the server hosting the gateway
+	# has several interfaces, and you only want a subset to be used. Any of
+	# the following examples are valid:
+	#     ice_enforce_list = "eth0"
+	#     ice_enforce_list = "eth0,eth1"
+	#     ice_enforce_list = "eth0,192.168."
+	#     ice_enforce_list = "eth0,192.168.0.1"
+	# By default, no interface is enforced, meaning Janus will try to use them all.
+	#ice_enforce_list = "eth0"
+
+	# In case you don't want to specify specific interfaces to use, but would
+	# rather tell Janus to use all the available interfaces except some that
+	# you don't want to involve, you can also choose which interfaces or IP
+	# addresses should be excluded and ignored by the gateway for the purpose
+	# of ICE candidates gathering. To do so, use the 'ice_ignore_list' setting
+	# and pass it a comma-separated list of interfaces or IP addresses to
+	# ignore. This is especially useful if the server hosting the gateway
+	# has several interfaces you already know will not be used or will simply
+	# always slow down ICE (e.g., virtual interfaces created by VMware).
+	# Partial strings are supported, which means that any of the following
+	# examples are valid:
+	#     ice_ignore_list = "vmnet8,192.168.0.1,10.0.0.1"
+	#     ice_ignore_list = "vmnet,192.168."
+	# Just beware that the ICE ignore list is not used if an enforce list
+	# has been configured. By default, Janus ignores all interfaces whose
+	# name starts with 'vmnet', to skip VMware interfaces:
+	ice_ignore_list = "vmnet"
+
+	# In case you want to allow Janus to start even if the configured STUN or TURN
+	# server is unreachable, you can set 'ignore_unreachable_ice_server' to true.
+	# WARNING: We do not recommend to ignore reachability problems, particularly
+	# if you run Janus in the cloud. Before enabling this flag, make sure your
+	# system is correctly configured and Janus starts after the network layer of
+	# your machine is ready. Note that Linux distributions offer such directives.
+	# You could use the following directive in systemd: 'After=network-online.target'
+	# https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Before=
+	#ignore_unreachable_ice_server = true
+}
+
+# You can choose which of the available plugins should be
+# enabled or not. Use the 'disable' directive to prevent Janus from
+# loading one or more plugins: use a comma separated list of plugin file
+# names to identify the plugins to disable. By default all available
+# plugins are enabled and loaded at startup.
+plugins: {
+	#disable = "libjanus_voicemail.so,libjanus_recordplay.so"
+}
+
+# You can choose which of the available transports should be enabled or
+# not. Use the 'disable' directive to prevent Janus from loading one
+# or more transport: use a comma separated list of transport file names
+# to identify the transports to disable. By default all available
+# transports are enabled and loaded at startup.
+transports: {
+	#disable = "libjanus_rabbitmq.so"
+}
+
+# As a core feature, Janus can log either on the standard output, or to
+# a local file. Should you need more advanced logging functionality, you
+# can make use of one of the custom loggers, or write one yourself. Use the
+# 'disable' directive to prevent Janus from loading one or more loggers:
+# use a comma separated list of logger file names to identify the loggers
+# to disable. By default all available loggers are enabled and loaded at startup.
+loggers: {
+	#disable = "libjanus_jsonlog.so"
+}
+
+# Event handlers allow you to receive live events from Janus happening
+# in core and/or plugins. Since this can require some more resources,
+# the feature is disabled by default. Setting broadcast to yes will
+# enable them. You can then choose which of the available event handlers
+# should be loaded or not. Use the 'disable' directive to prevent Janus
+# from loading one or more event handlers: use a comma separated list of
+# file names to identify the event handlers to disable. By default, if
+# broadcast is set to yes all available event handlers are enabled and
+# loaded at startup. Finally, you can choose how often media statistics
+# (packets sent/received, losses, etc.) should be sent: by default it's
+# once per second (audio and video statistics sent separately), but may
+# considered too verbose, or you may want to limit the number of events,
+# especially if you have many PeerConnections active. To change this,
+# just set 'stats_period' to the number of seconds that should pass in
+# between statistics for each handle. Setting it to 0 disables them (but
+# not other media-related events). By default Janus sends single media
+# statistic events per media (audio, video and simulcast layers as separate
+# events): if you'd rather receive a single containing all media stats in a
+# single array, set 'combine_media_stats' to true.
+events: {
+	#broadcast = true
+	#combine_media_stats = true
+	#disable = "libjanus_sampleevh.so"
+	#stats_period = 5
+}

--- a/docker/confs/janus.plugin.sfu.cfg
+++ b/docker/confs/janus.plugin.sfu.cfg
@@ -1,0 +1,15 @@
+[general]
+
+# The path to a file containing a secret key. If present, this key will be used to validate the signatures
+# of JWTs provided when joining rooms in the SFU plugin, and users will not be allowed to join without
+# a valid signed JWT.
+# auth_key = "foo.key"
+
+# If present, the maximum number of users allowed to join a single room. Zero means no limit.
+max_room_size = 30
+
+# If present, the maximum number of concurrent users allowed to join any room on the server. Zero means no limit.
+max_ccu = 1000
+
+# Number of threads to run message processing on. If zero, use the # of logical CPUs.
+message_threads = 0

--- a/docker/confs/janus.transport.http.jcfg
+++ b/docker/confs/janus.transport.http.jcfg
@@ -1,0 +1,74 @@
+# Web server stuff: whether any should be enabled, which ports they
+# should use, whether security should be handled directly or demanded to
+# an external application (e.g., web frontend) and what should be the
+# base path for the Janus API protocol. Notice that by default
+# all the web servers will try and bind on both IPv4 and IPv6: if you
+# want to only bind to IPv4 addresses (e.g., because your system does not
+# support IPv6), you should set the web server 'ip' property to '0.0.0.0'.
+# To see debug logs from the HTTP server library, set 'mhd_debug'.
+general: {
+	#events = true					# Whether to notify event handlers about transport events (default=true)
+	json = "indented"				# Whether the JSON messages should be indented (default),
+									# plain (no indentation) or compact (no indentation and no spaces)
+	base_path = "/janus"			# Base path to bind to in the web server (plain HTTP only)
+	http = false						# Whether to enable the plain HTTP interface
+	port = 8088						# Web server HTTP port
+	#interface = "eth0"				# Whether we should bind this server to a specific interface only
+	#ip = "192.168.0.1"				# Whether we should bind this server to a specific IP address (v4 or v6) only
+	https = false					# Whether to enable HTTPS (default=false)
+	#secure_port = 8089				# Web server HTTPS port, if enabled
+	#secure_interface = "eth0"		# Whether we should bind this server to a specific interface only
+	#secure_ip = "192.168.0.1"		# Whether we should bind this server to a specific IP address (v4 or v6) only
+	#acl = "127.,192.168.0."		# Only allow requests coming from this comma separated list of addresses
+	#mhd_connection_limit = 1020		# Open connections limit in libmicrohttpd (default=1020)
+	#mhd_debug = false					# Ask libmicrohttpd to write warning and error messages to stderr (default=false)
+}
+
+# Janus can also expose an admin/monitor endpoint, to allow you to check
+# which sessions are up, which handles they're managing, their current
+# status and so on. This provides a useful aid when debugging potential
+# issues in Janus. The configuration is pretty much the same as the one
+# already presented above for the webserver stuff, as the API is very
+# similar: choose the base bath for the admin/monitor endpoint (/admin
+# by default), ports, etc. Besides, you can specify
+# a secret that must be provided in all requests as a crude form of
+# authorization mechanism, and partial or full source IPs if you want to
+# limit access basing on IP addresses. For security reasons, this
+# endpoint is disabled by default, enable it by setting admin_http=true.
+admin: {
+	admin_base_path = "/admin"			# Base path to bind to in the admin/monitor web server (plain HTTP only)
+	admin_http = true					# Whether to enable the plain HTTP interface
+	admin_port = 7088					# Admin/monitor web server HTTP port
+	#admin_interface = "eth0"			# Whether we should bind this server to a specific interface only
+	#admin_ip = "192.168.0.1"			# Whether we should bind this server to a specific IP address (v4 or v6) only
+	admin_https = false					# Whether to enable HTTPS (default=false)
+	#admin_secure_port = 7889			# Admin/monitor web server HTTPS port, if enabled
+	#admin_secure_interface = "eth0"	# Whether we should bind this server to a specific interface only
+	#admin_secure_ip = "192.168.0.1		# Whether we should bind this server to a specific IP address (v4 or v6) only
+	#admin_acl = "127.,192.168.0."		# Only allow requests coming from this comma separated list of addresses
+}
+
+# The HTTP servers created in Janus support CORS out of the box, but by
+# default they return a wildcard (*) in the 'Access-Control-Allow-Origin'
+# header. This works fine in most situations, except when we have to
+# respond to a credential request (withCredentials=true in the XHR). If
+# you need that, uncomment and set the 'allow_origin' below to specify
+# what must be returned in 'Access-Control-Allow-Origin'. More details:
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
+# In case you want to enforce the Origin validation, rather than leave
+# it to browsers, you can set 'enforce_cors' to 'true' to have Janus
+# return a '403 Forbidden' for all requests that don't comply.
+cors: {
+	#allow_origin = "http://foo.example"
+	#enforce_cors = true
+}
+
+# Certificate and key to use for HTTPS, if enabled (and passphrase if needed).
+# You can also disable insecure protocols and ciphers by configuring the
+# 'ciphers' property accordingly (no limitation by default).
+certificates: {
+	#cert_pem = "/path/to/cert.pem"
+	#cert_key = "/path/to/key.pem"
+	#cert_pwd = "secretpassphrase"
+	#ciphers = "PFS:-VERS-TLS1.0:-VERS-TLS1.1:-3DES-CBC:-ARCFOUR-128"
+}

--- a/docker/confs/janus.transport.http.jcfg.sample
+++ b/docker/confs/janus.transport.http.jcfg.sample
@@ -1,0 +1,74 @@
+# Web server stuff: whether any should be enabled, which ports they
+# should use, whether security should be handled directly or demanded to
+# an external application (e.g., web frontend) and what should be the
+# base path for the Janus API protocol. Notice that by default
+# all the web servers will try and bind on both IPv4 and IPv6: if you
+# want to only bind to IPv4 addresses (e.g., because your system does not
+# support IPv6), you should set the web server 'ip' property to '0.0.0.0'.
+# To see debug logs from the HTTP server library, set 'mhd_debug'.
+general: {
+	#events = true					# Whether to notify event handlers about transport events (default=true)
+	json = "indented"				# Whether the JSON messages should be indented (default),
+									# plain (no indentation) or compact (no indentation and no spaces)
+	base_path = "/janus"			# Base path to bind to in the web server (plain HTTP only)
+	http = true						# Whether to enable the plain HTTP interface
+	port = 8088						# Web server HTTP port
+	#interface = "eth0"				# Whether we should bind this server to a specific interface only
+	#ip = "192.168.0.1"				# Whether we should bind this server to a specific IP address (v4 or v6) only
+	https = false					# Whether to enable HTTPS (default=false)
+	#secure_port = 8089				# Web server HTTPS port, if enabled
+	#secure_interface = "eth0"		# Whether we should bind this server to a specific interface only
+	#secure_ip = "192.168.0.1"		# Whether we should bind this server to a specific IP address (v4 or v6) only
+	#acl = "127.,192.168.0."		# Only allow requests coming from this comma separated list of addresses
+	#mhd_connection_limit = 1020		# Open connections limit in libmicrohttpd (default=1020)
+	#mhd_debug = false					# Ask libmicrohttpd to write warning and error messages to stderr (default=false)
+}
+
+# Janus can also expose an admin/monitor endpoint, to allow you to check
+# which sessions are up, which handles they're managing, their current
+# status and so on. This provides a useful aid when debugging potential
+# issues in Janus. The configuration is pretty much the same as the one
+# already presented above for the webserver stuff, as the API is very
+# similar: choose the base bath for the admin/monitor endpoint (/admin
+# by default), ports, etc. Besides, you can specify
+# a secret that must be provided in all requests as a crude form of
+# authorization mechanism, and partial or full source IPs if you want to
+# limit access basing on IP addresses. For security reasons, this
+# endpoint is disabled by default, enable it by setting admin_http=true.
+admin: {
+	admin_base_path = "/admin"			# Base path to bind to in the admin/monitor web server (plain HTTP only)
+	admin_http = false					# Whether to enable the plain HTTP interface
+	admin_port = 7088					# Admin/monitor web server HTTP port
+	#admin_interface = "eth0"			# Whether we should bind this server to a specific interface only
+	#admin_ip = "192.168.0.1"			# Whether we should bind this server to a specific IP address (v4 or v6) only
+	admin_https = false					# Whether to enable HTTPS (default=false)
+	#admin_secure_port = 7889			# Admin/monitor web server HTTPS port, if enabled
+	#admin_secure_interface = "eth0"	# Whether we should bind this server to a specific interface only
+	#admin_secure_ip = "192.168.0.1		# Whether we should bind this server to a specific IP address (v4 or v6) only
+	#admin_acl = "127.,192.168.0."		# Only allow requests coming from this comma separated list of addresses
+}
+
+# The HTTP servers created in Janus support CORS out of the box, but by
+# default they return a wildcard (*) in the 'Access-Control-Allow-Origin'
+# header. This works fine in most situations, except when we have to
+# respond to a credential request (withCredentials=true in the XHR). If
+# you need that, uncomment and set the 'allow_origin' below to specify
+# what must be returned in 'Access-Control-Allow-Origin'. More details:
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
+# In case you want to enforce the Origin validation, rather than leave
+# it to browsers, you can set 'enforce_cors' to 'true' to have Janus
+# return a '403 Forbidden' for all requests that don't comply.
+cors: {
+	#allow_origin = "http://foo.example"
+	#enforce_cors = true
+}
+
+# Certificate and key to use for HTTPS, if enabled (and passphrase if needed).
+# You can also disable insecure protocols and ciphers by configuring the
+# 'ciphers' property accordingly (no limitation by default).
+certificates: {
+	#cert_pem = "/path/to/cert.pem"
+	#cert_key = "/path/to/key.pem"
+	#cert_pwd = "secretpassphrase"
+	#ciphers = "PFS:-VERS-TLS1.0:-VERS-TLS1.1:-3DES-CBC:-ARCFOUR-128"
+}

--- a/docker/confs/janus.transport.pfunix.jcfg
+++ b/docker/confs/janus.transport.pfunix.jcfg
@@ -1,0 +1,23 @@
+# You can also control a Janus instance using Unix Sockets. The only
+# aspect you need to configure here is the path of the Unix Sockets
+# server. Notice that by default the interface is disabled, as you need
+# to specify the path(s) to bind to for the API(s).
+general: {
+	enabled = false					# Whether to enable the Unix Sockets interface
+									# for Janus API clients
+	#events = true					# Whether to notify event handlers about transport events (default=true)
+	json = "indented"				# Whether the JSON messages should be indented (default),
+									# plain (no indentation) or compact (no indentation and no spaces)
+	#path = "/path/to/ux-janusapi"	# Path to bind to (Janus API)
+	#type = "SOCK_SEQPACKET"		# SOCK_SEQPACKET (default) or SOCK_DGRAM?
+}
+
+# As with other transport plugins, you can use Unix Sockets to interact
+# with the Admin API as well: in case you're interested in it, a different
+# path needs to be provided.
+admin: {
+	admin_enabled = false					# Whether to enable the Unix Sockets interface
+											# for Admin API clients
+	#admin_path = "/path/to/ux-janusadmin"	# Path to bind to (Admin API)
+	#admin_type = "SOCK_SEQPACKET"			# SOCK_SEQPACKET (default) or SOCK_DGRAM?
+}

--- a/docker/confs/janus.transport.pfunix.jcfg.sample
+++ b/docker/confs/janus.transport.pfunix.jcfg.sample
@@ -1,0 +1,23 @@
+# You can also control a Janus instance using Unix Sockets. The only
+# aspect you need to configure here is the path of the Unix Sockets
+# server. Notice that by default the interface is disabled, as you need
+# to specify the path(s) to bind to for the API(s).
+general: {
+	enabled = false					# Whether to enable the Unix Sockets interface
+									# for Janus API clients
+	#events = true					# Whether to notify event handlers about transport events (default=true)
+	json = "indented"				# Whether the JSON messages should be indented (default),
+									# plain (no indentation) or compact (no indentation and no spaces)
+	#path = "/path/to/ux-janusapi"	# Path to bind to (Janus API)
+	#type = "SOCK_SEQPACKET"		# SOCK_SEQPACKET (default) or SOCK_DGRAM?
+}
+
+# As with other transport plugins, you can use Unix Sockets to interact
+# with the Admin API as well: in case you're interested in it, a different
+# path needs to be provided.
+admin: {
+	admin_enabled = false					# Whether to enable the Unix Sockets interface
+											# for Admin API clients
+	#admin_path = "/path/to/ux-janusadmin"	# Path to bind to (Admin API)
+	#admin_type = "SOCK_SEQPACKET"			# SOCK_SEQPACKET (default) or SOCK_DGRAM?
+}

--- a/docker/confs/janus.transport.websockets.jcfg
+++ b/docker/confs/janus.transport.websockets.jcfg
@@ -1,0 +1,68 @@
+# WebSockets stuff: whether they should be enabled, which ports they
+# should use, and so on.
+general: {
+	#events = true					# Whether to notify event handlers about transport events (default=true)
+	json = "indented"				# Whether the JSON messages should be indented (default),
+									# plain (no indentation) or compact (no indentation and no spaces)
+	#pingpong_trigger = 30			# After how many seconds of idle, a PING should be sent
+	#pingpong_timeout = 10			# After how many seconds of not getting a PONG, a timeout should be detected
+
+	ws = true						# Whether to enable the WebSockets API
+	ws_port = 8188					# WebSockets server port
+	#ws_interface = "eth0"			# Whether we should bind this server to a specific interface only
+	#ws_ip = "192.168.0.1"			# Whether we should bind this server to a specific IP address only
+	#ws_unix = "/run/ws.sock"		# Use WebSocket server over UNIX socket instead of TCP
+	wss = false						# Whether to enable secure WebSockets
+	#wss_port = 8989				# WebSockets server secure port, if enabled
+	#wss_interface = "eth0"			# Whether we should bind this server to a specific interface only
+	#wss_ip = "192.168.0.1"			# Whether we should bind this server to a specific IP address only
+	#wss_unix = "/run/wss.sock"		# Use WebSocket server over UNIX socket instead of TCP
+	#ws_logging = "err,warn"		# libwebsockets debugging level as a comma separated list of things
+									# to debug, supported values: err, warn, notice, info, debug, parser,
+									# header, ext, client, latency, user, count (plus 'none' and 'all')
+	#ws_acl = "127.,192.168.0."		# Only allow requests coming from this comma separated list of addresses
+}
+
+# If you want to expose the Admin API via WebSockets as well, you need to
+# specify a different server instance, as you cannot mix Janus API and
+# Admin API messaging. Notice that by default the Admin API support via
+# WebSockets is disabled.
+admin: {
+	admin_ws = false					# Whether to enable the Admin API WebSockets API
+	admin_ws_port = 7188				# Admin API WebSockets server port, if enabled
+	#admin_ws_interface = "eth0"		# Whether we should bind this server to a specific interface only
+	#admin_ws_ip = "192.168.0.1"		# Whether we should bind this server to a specific IP address only
+	#admin_ws_unix = "/run/aws.sock"	# Use WebSocket server over UNIX socket instead of TCP
+	admin_wss = false					# Whether to enable the Admin API secure WebSockets
+	#admin_wss_port = 7989				# Admin API WebSockets server secure port, if enabled
+	#admin_wss_interface = "eth0"		# Whether we should bind this server to a specific interface only
+	#admin_wss_ip = "192.168.0.1"		# Whether we should bind this server to a specific IP address only
+	#admin_wss_unix = "/run/awss.sock"	# Use WebSocket server over UNIX socket instead of TCP
+	#admin_ws_acl = "127.,192.168.0."	# Only allow requests coming from this comma separated list of addresses
+}
+
+# The HTTP servers created in Janus support CORS out of the box, but by
+# default they return a wildcard (*) in the 'Access-Control-Allow-Origin'
+# header. This works fine in most situations, except when we have to
+# respond to a credential request (withCredentials=true in the XHR). If
+# you need that, uncomment and set the 'allow_origin' below to specify
+# what must be returned in 'Access-Control-Allow-Origin'. More details:
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
+# In case you want to enforce the Origin validation, rather than leave
+# it to browsers, you can set 'enforce_cors' to 'true' to have Janus
+# return a '403 Forbidden' for all requests that don't comply.
+cors: {
+	#allow_origin = "http://foo.example"
+	#enforce_cors = true
+}
+
+# Certificate and key to use for any secure WebSocket server, if enabled (and passphrase if needed).
+# You can also disable insecure protocols and ciphers by configuring the
+# 'ciphers' property accordingly (no limitation by default).
+# Examples of recommended cipher strings at https://cheatsheetseries.owasp.org/cheatsheets/TLS_Cipher_String_Cheat_Sheet.html
+certificates: {
+	#cert_pem = "/path/to/cert.pem"
+	#cert_key = "/path/to/key.pem"
+	#cert_pwd = "secretpassphrase"
+	#ciphers = "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256"
+}

--- a/docker/confs/janus.transport.websockets.jcfg.sample
+++ b/docker/confs/janus.transport.websockets.jcfg.sample
@@ -1,0 +1,68 @@
+# WebSockets stuff: whether they should be enabled, which ports they
+# should use, and so on.
+general: {
+	#events = true					# Whether to notify event handlers about transport events (default=true)
+	json = "indented"				# Whether the JSON messages should be indented (default),
+									# plain (no indentation) or compact (no indentation and no spaces)
+	#pingpong_trigger = 30			# After how many seconds of idle, a PING should be sent
+	#pingpong_timeout = 10			# After how many seconds of not getting a PONG, a timeout should be detected
+
+	ws = true						# Whether to enable the WebSockets API
+	ws_port = 8188					# WebSockets server port
+	#ws_interface = "eth0"			# Whether we should bind this server to a specific interface only
+	#ws_ip = "192.168.0.1"			# Whether we should bind this server to a specific IP address only
+	#ws_unix = "/run/ws.sock"		# Use WebSocket server over UNIX socket instead of TCP
+	wss = false						# Whether to enable secure WebSockets
+	#wss_port = 8989				# WebSockets server secure port, if enabled
+	#wss_interface = "eth0"			# Whether we should bind this server to a specific interface only
+	#wss_ip = "192.168.0.1"			# Whether we should bind this server to a specific IP address only
+	#wss_unix = "/run/wss.sock"		# Use WebSocket server over UNIX socket instead of TCP
+	#ws_logging = "err,warn"		# libwebsockets debugging level as a comma separated list of things
+									# to debug, supported values: err, warn, notice, info, debug, parser,
+									# header, ext, client, latency, user, count (plus 'none' and 'all')
+	#ws_acl = "127.,192.168.0."		# Only allow requests coming from this comma separated list of addresses
+}
+
+# If you want to expose the Admin API via WebSockets as well, you need to
+# specify a different server instance, as you cannot mix Janus API and
+# Admin API messaging. Notice that by default the Admin API support via
+# WebSockets is disabled.
+admin: {
+	admin_ws = false					# Whether to enable the Admin API WebSockets API
+	admin_ws_port = 7188				# Admin API WebSockets server port, if enabled
+	#admin_ws_interface = "eth0"		# Whether we should bind this server to a specific interface only
+	#admin_ws_ip = "192.168.0.1"		# Whether we should bind this server to a specific IP address only
+	#admin_ws_unix = "/run/aws.sock"	# Use WebSocket server over UNIX socket instead of TCP
+	admin_wss = false					# Whether to enable the Admin API secure WebSockets
+	#admin_wss_port = 7989				# Admin API WebSockets server secure port, if enabled
+	#admin_wss_interface = "eth0"		# Whether we should bind this server to a specific interface only
+	#admin_wss_ip = "192.168.0.1"		# Whether we should bind this server to a specific IP address only
+	#admin_wss_unix = "/run/awss.sock"	# Use WebSocket server over UNIX socket instead of TCP
+	#admin_ws_acl = "127.,192.168.0."	# Only allow requests coming from this comma separated list of addresses
+}
+
+# The HTTP servers created in Janus support CORS out of the box, but by
+# default they return a wildcard (*) in the 'Access-Control-Allow-Origin'
+# header. This works fine in most situations, except when we have to
+# respond to a credential request (withCredentials=true in the XHR). If
+# you need that, uncomment and set the 'allow_origin' below to specify
+# what must be returned in 'Access-Control-Allow-Origin'. More details:
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
+# In case you want to enforce the Origin validation, rather than leave
+# it to browsers, you can set 'enforce_cors' to 'true' to have Janus
+# return a '403 Forbidden' for all requests that don't comply.
+cors: {
+	#allow_origin = "http://foo.example"
+	#enforce_cors = true
+}
+
+# Certificate and key to use for any secure WebSocket server, if enabled (and passphrase if needed).
+# You can also disable insecure protocols and ciphers by configuring the
+# 'ciphers' property accordingly (no limitation by default).
+# Examples of recommended cipher strings at https://cheatsheetseries.owasp.org/cheatsheets/TLS_Cipher_String_Cheat_Sheet.html
+certificates: {
+	#cert_pem = "/path/to/cert.pem"
+	#cert_key = "/path/to/key.pem"
+	#cert_pwd = "secretpassphrase"
+	#ciphers = "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256"
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.7"
+services:
+  janus:
+    network_mode: host
+    restart: always
+    build: .
+    image: janus:latest
+    environment:
+      - ADMIN_SECRET
+      - DEBUG_LEVEL
+      - MAX_CCU
+      - MAX_ROOM_SIZE
+      - MESSAGE_THREADS
+      - SESSION_TIMEOUT
+#      - AUTH_KEY=/keys/public.der 
+#    volumes:
+#      - ./public.der:/keys/public.der:ro

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+ADMIN_SECRET=${ADMIN_SECRET:-janusoverlord}
+DEBUG_LEVEL=${DEBUG_LEVEL:-4}
+SESSION_TIMEOUT=${SESSION_TIMEOUT:-38}
+MIN_NACK_QUEUE=${MIN_NACK_QUEUE:-200}
+
+if [ -z "$NETWORK_INTERFACE" ]; then
+    # if NETWORK_INTERFACE is empty then we are on k8s
+    NETWORK_INTERFACE=$(ip -br link|grep " UP "|head -1|awk '{print $1}')
+    # There is no other way to know the external node ip.
+    # See https://github.com/kubernetes/kubernetes/issues/73760
+    PUBLIC_IP=$(curl --silent https://ipinfo.io/ip)
+    if [ -z "$PUBLIC_IP" ]; then
+        echo "Couldn't get the node public ip"
+        exit 1
+    fi
+fi
+
+if [ ! -z "$NETWORK_INTERFACE" ]; then
+    sed -i \
+        -e "s|#ice_enforce_list =.*|ice_enforce_list = \"${NETWORK_INTERFACE}\"|" \
+         /usr/etc/janus/janus.jcfg
+fi
+if [ ! -z "$PUBLIC_IP" ]; then
+#        -e 's|#stun_server =.*|stun_server = "stun1.l.google.com"|' \
+#        -e 's|#stun_port =.*|stun_port = 19302|' \
+    sed -i \
+        -e "s|#nat_1_1_mapping =.*|nat_1_1_mapping = \"${PUBLIC_IP}\"|" \
+        -e "s|debug_level =.*|debug_level = \"${DEBUG_LEVEL}\"|" \
+        /usr/etc/janus/janus.jcfg
+fi
+sed -i \
+    -e "s|admin_secret =.*|admin_secret = \"${ADMIN_SECRET}\"|" \
+    -e "s|#session_timeout = 60|session_timeout = ${SESSION_TIMEOUT}|" \
+    -e "s|#min_nack_queue =.*|min_nack_queue = ${MIN_NACK_QUEUE}|" \
+    /usr/etc/janus/janus.jcfg
+
+
+if [ ! -z "$AUTH_KEY" ]; then
+    sed -i \
+        -e "s|.*auth_key =.*|auth_key = \"${AUTH_KEY}\"|" \
+        /usr/etc/janus/janus.plugin.sfu.cfg
+fi
+
+MAX_ROOM_SIZE=${MAX_ROOM_SIZE:-30}
+MAX_CCU=${MAX_CCU:-1000}
+MESSAGE_THREADS=${MESSAGE_THREADS:-0}
+sed -i \
+    -e "s|max_room_size =.*|max_room_size = ${MAX_ROOM_SIZE}|" \
+    -e "s|max_ccu =.*|max_ccu = ${MAX_CCU}|" \
+    -e "s|message_threads =.*|message_threads = ${MESSAGE_THREADS}|" \
+    /usr/etc/janus/janus.plugin.sfu.cfg
+
+exec "$@"


### PR DESCRIPTION
This is the docker image I'm currently using.
The Dockerfile uses the same instructions as the current install doc with an ubuntu instance with systemd, except using latest 0.x branch janus-gateway (a commit post 0.11.8) and the disable-subscribe-message branch #2

The `start.sh` script is using `sed` commands to replace some environment variables in the config files.
I left the .sample files that are created in a default 0.11.8 janus install, so you can compare for example `janus.jcfg.sample` and `janus.jcfg` to see what options I changed that may not be configurable via environment variables in my `start.sh` entrypoint script.
Instead of `sed` commands, we could use modify `janus.jcfg` with dollar variables and use the `envsubst` command (in the `gettext-base` package on ubuntu), or any other light template system. I didn't know about `envsubst` command when I did this script.
A good point of not replacing all options in `janus.jcfg` (and the other conf files) with variables allows me compare easily the files with the original files.

Instead of relying on an external service to get the public ip when the janus container starts, see `start.sh` line 13
we could use a dns query like they did on the new official coturn docker image
https://github.com/coturn/coturn/blob/master/docker/coturn/rootfs/usr/local/bin/detect-external-ip.sh