### PR TITLE
Add ARM compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,12 +114,12 @@ checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 [[package]]
 name = "jansson-sys"
 version = "0.1.0"
-source = "git+https://github.com/networked-aframe/janus-plugin-rs?branch=master#b05985139f39158d5bb676f3f91e81e53cd778ad"
+source = "git+https://github.com/networked-aframe/janus-plugin-rs?branch=master#b960ac5705f0a039379749dde327f98f2efe42a3"
 
 [[package]]
 name = "janus-plugin"
 version = "0.13.0"
-source = "git+https://github.com/networked-aframe/janus-plugin-rs?branch=master#b05985139f39158d5bb676f3f91e81e53cd778ad"
+source = "git+https://github.com/networked-aframe/janus-plugin-rs?branch=master#b960ac5705f0a039379749dde327f98f2efe42a3"
 dependencies = [
  "bitflags",
  "chrono",
@@ -147,7 +147,7 @@ dependencies = [
 [[package]]
 name = "janus-plugin-sys"
 version = "0.8.0"
-source = "git+https://github.com/networked-aframe/janus-plugin-rs?branch=master#b05985139f39158d5bb676f3f91e81e53cd778ad"
+source = "git+https://github.com/networked-aframe/janus-plugin-rs?branch=master#b960ac5705f0a039379749dde327f98f2efe42a3"
 dependencies = [
  "glib-sys",
  "jansson-sys",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,12 @@
 FROM ubuntu:20.04
+# If you want to build the docker image on Raspberry Pi OS (based on debian bullseye)
+# and then copy the build artifacts on the host to run janus without docker,
+# comment "FROM ubuntu:20.04" and uncomment those two lines:
+# FROM debian:bullseye
+# RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
+# Installing rustup is needed to have a recent cargo version (1.61.0),
+# ubuntu:20.04 uses cargo 1.57.0 that is recent enough, but debian:bullseye uses cargo 1.46.0
+# that has an issue that produces the error "error inflating zlib stream; class=Zlib" when getting crate dependencies.
 
 RUN apt-get -y update && DEBIAN_FRONTEND="noninteractive" TZ="Europe/Paris" apt-get -y upgrade
 RUN apt-get -y update && DEBIAN_FRONTEND="noninteractive" TZ="Europe/Paris" apt-get install -y libmicrohttpd-dev \


### PR DESCRIPTION
Update janus-plugin-rs version to include https://github.com/networked-aframe/janus-plugin-rs/pull/1 so we can now build the rust plugin on ARM platforms (tested on my Raspberry Pi 2B)