### PR TITLE
Reenable subscribe message with security

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -121,11 +121,16 @@ you use the Join message to subscribe to other users, not this message.
 {
     "kind": "subscribe",
     "what": {
+        "notifications": [none|boolean],
+        "data": [none|boolean],
         "media": [none|user ID]
     },
     "token": [none|string]
 }
 ```
+
+`notifications` and `data` are completely ignored here. Those flags are only
+checked for a publisher connection with the Join message.
 
 If `media` is a user ID, the server will respond with a JSEP offer which you can use to establish a connection suitable to receive audio and video RTP data coming from that user ID.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -117,7 +117,7 @@ Kick another user from the room. You need a token with the `kick_users: true` cl
     "kind": "kick",
     "room_id": room ID,
     "user_id": user ID,
-    "token": [none|string]
+    "token": [string]
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -568,27 +568,27 @@ fn process_unblock(from: &Arc<Session>, whom: UserId) -> MessageResult {
     }
 }
 
-// fn process_subscribe(from: &Arc<Session>, what: &Subscription) -> MessageResult {
-//     janus_info!("Processing subscription from {:p}: {:?}", from.handle, what);
-//     if let Err(_existing) = from.subscription.set(what.clone()) {
-//         return Err(From::from("Users may only subscribe once!"));
-//     }
+fn process_subscribe(from: &Arc<Session>, what: &Subscription) -> MessageResult {
+    janus_info!("Processing subscription from {:p}: {:?}", from.handle, what);
+    if let Err(_existing) = from.subscription.set(what.clone()) {
+        return Err(From::from("Users may only subscribe once!"));
+    }
 
-//     let mut switchboard = SWITCHBOARD.write()?;
-//     if let Some(ref publisher_id) = what.media {
-//         let publisher = switchboard
-//             .get_publisher(publisher_id)
-//             .ok_or("Can't subscribe to a nonexistent publisher.")?
-//             .clone();
-//         let jsep = json!({
-//             "type": "offer",
-//             "sdp": publisher.subscriber_offer.lock().unwrap().as_ref().unwrap()
-//         });
-//         switchboard.subscribe_to_user(from.clone(), publisher);
-//         return Ok(MessageResponse::new(json!({}), jsep));
-//     }
-//     Ok(MessageResponse::msg(json!({})))
-// }
+    let mut switchboard = SWITCHBOARD.write()?;
+    if let Some(ref publisher_id) = what.media {
+        let publisher = switchboard
+            .get_publisher(publisher_id)
+            .ok_or("Can't subscribe to a nonexistent publisher.")?
+            .clone();
+        let jsep = json!({
+            "type": "offer",
+            "sdp": publisher.subscriber_offer.lock().unwrap().as_ref().unwrap()
+        });
+        switchboard.subscribe_to_user(from.clone(), publisher);
+        return Ok(MessageResponse::new(json!({}), jsep));
+    }
+    Ok(MessageResponse::msg(json!({})))
+}
 
 fn process_data(from: &Arc<Session>, whom: Option<UserId>, body: &str) -> MessageResult {
     janus_huge!("Processing data message from {:p}: {:?}", from.handle, body);
@@ -616,9 +616,7 @@ fn process_message(from: &Arc<Session>, msg: MessageKind) -> MessageResult {
             token,
         } => process_join(from, room_id, user_id, subscribe, token),
         MessageKind::Kick { room_id, user_id, token } => process_kick(from, room_id, user_id, token),
-        // process_subscribe doesn't check the JWT, we need to change the API to add room_id and token,
-        // comment it for now.
-        // MessageKind::Subscribe { what } => process_subscribe(from, &what),
+        MessageKind::Subscribe { what } => process_subscribe(from, &what),
         MessageKind::Block { whom } => process_block(from, whom),
         MessageKind::Unblock { whom } => process_unblock(from, whom),
         MessageKind::Data { whom, body } => process_data(from, whom, &body),

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -88,7 +88,7 @@ pub enum MessageKind {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default)]
 pub struct Subscription {
-    /// Whether to subscribe to server-wide notifications (e.g. user joins and leaves, room creates and destroys).
+    /// Whether to subscribe to server-wide notifications (e.g. user joins and leaves, someone blocked/unblocked you).
     pub notifications: bool,
 
     /// Whether to subscribe to data in the currently-joined room.

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -71,7 +71,7 @@ pub enum MessageKind {
     Kick { room_id: RoomId, user_id: UserId, token: String },
 
     /// Indicates that a client wishes to subscribe to traffic described by the given subscription specification.
-    Subscribe { what: Subscription },
+    Subscribe { what: Subscription, token: Option<String> },
 
     /// Indicates that a given user should be blocked from receiving your traffic, and that you should not
     /// receive their traffic (superseding any subscriptions you have.)
@@ -174,7 +174,8 @@ mod tests {
                         notifications: false,
                         data: true,
                         media: Some("steve".into())
-                    }
+                    },
+                    token: None
                 }
             );
         }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -71,7 +71,7 @@ pub enum MessageKind {
     Kick { room_id: RoomId, user_id: UserId, token: String },
 
     /// Indicates that a client wishes to subscribe to traffic described by the given subscription specification.
-    // Subscribe { what: Subscription },
+    Subscribe { what: Subscription },
 
     /// Indicates that a given user should be blocked from receiving your traffic, and that you should not
     /// receive their traffic (superseding any subscriptions you have.)
@@ -163,20 +163,20 @@ mod tests {
             );
         }
 
-        // #[test]
-        // fn parse_subscribe() {
-        //     let json = r#"{"kind": "subscribe", "what": {"notifications": false, "data": true, "media": "steve"}}"#;
-        //     let result: MessageKind = serde_json::from_str(json).unwrap();
-        //     assert_eq!(
-        //         result,
-        //         MessageKind::Subscribe {
-        //             what: Subscription {
-        //                 notifications: false,
-        //                 data: true,
-        //                 media: Some("steve".into())
-        //             }
-        //         }
-        //     );
-        // }
+        #[test]
+        fn parse_subscribe() {
+            let json = r#"{"kind": "subscribe", "what": {"notifications": false, "data": true, "media": "steve"}}"#;
+            let result: MessageKind = serde_json::from_str(json).unwrap();
+            assert_eq!(
+                result,
+                MessageKind::Subscribe {
+                    what: Subscription {
+                        notifications: false,
+                        data: true,
+                        media: Some("steve".into())
+                    }
+                }
+            );
+        }
     }
 }


### PR DESCRIPTION
Reenable subscribe message that was commented in #2 and add proper JWT check.
This closes https://github.com/mozilla/janus-plugin-sfu/issues/83 and https://github.com/mozilla/janus-plugin-sfu/pull/86