### PR TITLE
add env variables EVENT_LOOPS and ALLOW_LOOP_INDICATION

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -31,6 +31,13 @@ MAX_CCU=1000
 MESSAGE_THREADS=0
 ```
 
+In order to take advantage of event loops / loop indication, the respective environment variables are available:
+
+``` 
+EVENT_LOOPS="true"
+ALLOW_LOOP_INDICATION="true"
+```
+
 The default values are defined at the beginning of the `start.sh` script.
 
 ## Installing docker

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -43,6 +43,18 @@ if [ ! -z "$AUTH_KEY" ]; then
         /usr/etc/janus/janus.plugin.sfu.cfg
 fi
 
+if [ ! -z "$EVENT_LOOPS" ]; then
+    sed -i \
+        -e "s|#event_loops =.*|event_loops = ${EVENT_LOOPS}|" \
+        /usr/etc/janus/janus.jcfg
+fi
+
+if [ ! -z "$ALLOW_LOOP_INDICATION" ]; then
+    sed -i \
+        -e "s|#allow_loop_indication =.*|allow_loop_indication = ${ALLOW_LOOP_INDICATION}|" \
+        /usr/etc/janus/janus.cfg
+fi
+
 MAX_ROOM_SIZE=${MAX_ROOM_SIZE:-30}
 MAX_CCU=${MAX_CCU:-1000}
 MESSAGE_THREADS=${MESSAGE_THREADS:-0}


### PR DESCRIPTION
As discussed [here](https://github.com/networked-aframe/naf-janus-adapter/pull/49#issuecomment-1588786332), this PR introduces `EVENT_LOOPS` and `ALLOW_LOOP_INDICATION` env variables for docker.