### PR TITLE
Be sure the /start script is executable in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -98,6 +98,7 @@ RUN git clone -b master https://github.com/networked-aframe/janus-plugin-sfu.git
 COPY confs/* /usr/etc/janus/
 RUN chown -R nobody:nogroup /usr/etc/janus/
 COPY start.sh /start
+RUN chmod 775 /start
 
 USER nobody:nogroup
 ENTRYPOINT ["/start"]


### PR DESCRIPTION
Be sure the /start script is executable in the docker image.
It may not be if you cloned the repo on a filesytem not supporting the execution flag, like ntfs on Windows.