### PR TITLE
Update docker image to ubuntu:24.04 and latest versions of dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,34 @@
 version = 3
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "aho-corasick"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
- "hermit-abi",
+ "memchr",
+]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
  "libc",
- "winapi",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "base64"
@@ -27,9 +40,9 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bitflags"
@@ -39,15 +52,25 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
+]
 
 [[package]]
 name = "cfg-if"
@@ -57,71 +80,116 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
- "libc",
- "num-integer",
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
- "time",
- "winapi",
+ "wasm-bindgen",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
 name = "colored"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
- "atty",
  "lazy_static",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
-name = "glib-sys"
-version = "0.10.1"
+name = "core-foundation-sys"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e9b997a66e9a23d073f2b1abb4dbfc3925e0b8952f67efd8d9b6e168e4cdc1"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "glib-sys"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767d23ead9bbdfcbb1c2242c155c8128a7d13dde7bf69c176f809546135e2282"
 dependencies = [
  "libc",
  "system-deps",
 ]
 
 [[package]]
-name = "heck"
-version = "0.3.3"
+name = "hashbrown"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
- "libc",
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jansson-sys"
 version = "0.1.0"
-source = "git+https://github.com/networked-aframe/janus-plugin-rs?branch=master#a069590c8781677535d1845c97e7a09bdba2b929"
+source = "git+https://github.com/networked-aframe/janus-plugin-rs?branch=master#4a099e583ef3aa5b88f517a6a174e5ae048910d1"
 
 [[package]]
 name = "janus-plugin"
 version = "0.13.0"
-source = "git+https://github.com/networked-aframe/janus-plugin-rs?branch=master#a069590c8781677535d1845c97e7a09bdba2b929"
+source = "git+https://github.com/networked-aframe/janus-plugin-rs?branch=master#4a099e583ef3aa5b88f517a6a174e5ae048910d1"
 dependencies = [
  "bitflags",
  "chrono",
@@ -149,7 +217,7 @@ dependencies = [
 [[package]]
 name = "janus-plugin-sys"
 version = "0.8.0"
-source = "git+https://github.com/networked-aframe/janus-plugin-rs?branch=master#a069590c8781677535d1845c97e7a09bdba2b929"
+source = "git+https://github.com/networked-aframe/janus-plugin-rs?branch=master#4a099e583ef3aa5b88f517a6a174e5ae048910d1"
 dependencies = [
  "glib-sys",
  "jansson-sys",
@@ -157,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.58"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -186,18 +254,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "memchr"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "num-bigint"
@@ -212,28 +283,27 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -241,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "pem"
@@ -251,49 +321,63 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "once_cell",
  "regex",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "ring"
@@ -318,24 +402,24 @@ checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -344,12 +428,21 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
  "serde",
 ]
 
@@ -365,34 +458,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "strum"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b"
-
-[[package]]
-name = "strum_macros"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "syn"
-version = "1.0.98"
+version = "2.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -401,70 +482,62 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "1.3.2"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3ecc17269a19353b3558b313bba738b25d82993e30d62a18406a24aba4649b"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
+ "cfg-expr",
  "heck",
  "pkg-config",
- "strum",
- "strum_macros",
- "thiserror",
  "toml",
  "version-compare",
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.31"
+name = "target-lexicon"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi",
- "winapi",
-]
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.1"
+name = "toml_edit"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
+name = "unicode-ident"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "untrusted"
@@ -474,21 +547,15 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "version-compare"
-version = "0.0.10"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d63556a25bae6ea31b52e640d7c41d1ab27faba4ccb600013837a3d0b3994ca1"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.81"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -496,13 +563,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.81"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -511,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.81"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -521,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.81"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -534,15 +601,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.81"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.58"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -569,3 +636,151 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
 name = "janus-plugin-sfu"
 version = "0.1.0"
 dependencies = [
+ "glib-sys",
  "janus-plugin",
  "jsonwebtoken",
  "num_cpus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ lto = true
 
 [dependencies]
 janus-plugin = "0.13"
-once_cell = "1.2"
+once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rust-ini = "0.13"
-jsonwebtoken = "7.0"
-num_cpus = "1.12.0"
+jsonwebtoken = "7.2"
+num_cpus = "1.16.0"
 
 [patch.crates-io]
 janus-plugin-sys = { git = "https://github.com/networked-aframe/janus-plugin-rs", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ crate_type = ["cdylib"]
 lto = true
 
 [dependencies]
+glib-sys = "0.19"
 janus-plugin = "0.13"
 once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ FROM ubuntu:24.04
 # Look at the version used in
 # https://github.com/meetecho/janus-gateway/blob/master/.github/workflows/janus-ci.yml
 
-# For a debug build with libasan, remove cargo from apt list, add libasan8, uncomment JANUS_DEBUG_CFLAGS and JANUS_DEBUG_LDFLAGS and use the janus-plugin-sfu debug intructions.
+# For a debug build with libasan, remove cargo from apt list, add libasan8, uncomment JANUS_DEBUG_CFLAGS and JANUS_DEBUG_LDFLAGS and use the janus-plugin-sfu debug instructions.
 # Run with:
 # docker run --net=host -e EVENT_LOOPS=4 -e MESSAGE_THREADS=1 janus:latest
 # to see the memory leaks on stdout when you ctrl+c the container if any. Using docker compose up don't show anything.
@@ -34,8 +34,8 @@ RUN apt-get -y update && DEBIAN_FRONTEND="noninteractive" TZ="Europe/Paris" apt-
     cmake \
     unzip \
     zip \
-#    cargo \
-    libasan8 \
+    cargo \
+#    libasan8 \
     wget \
     curl \
     iproute2 && \
@@ -87,8 +87,8 @@ RUN git clone https://github.com/sctplab/usrsctp.git && \
 
 # 2024-05-09 12:46 (post v0.14.2 from 0.x branch)
 ENV JANUS_COMMIT="a7767ad30b803d96e11b491547bcf5660cb7a937"
-ENV JANUS_DEBUG_CFLAGS="-O1 -g -ggdb3 -fsanitize=address -fno-sanitize-recover=all -fsanitize-address-use-after-scope"
-ENV JANUS_DEBUG_LDFLAGS="-fsanitize=address"
+# ENV JANUS_DEBUG_CFLAGS="-O1 -g -ggdb3 -fsanitize=address -fno-sanitize-recover=all -fsanitize-address-use-after-scope"
+# ENV JANUS_DEBUG_LDFLAGS="-fsanitize=address"
 COPY g_list_free_pts.patch /
 RUN git clone -b 0.x https://github.com/meetecho/janus-gateway.git && \
     cd janus-gateway && \
@@ -101,29 +101,27 @@ RUN git clone -b 0.x https://github.com/meetecho/janus-gateway.git && \
 
 ENV JANUS_SFU_COMMIT="4226d0091b386576d221988c76e11c0d0ef7d215"
 # janus-plugin-sfu release build:
-#RUN git clone -b master https://github.com/networked-aframe/janus-plugin-sfu.git && \
-#    cd janus-plugin-sfu && \
-#    git checkout ${JANUS_SFU_COMMIT} && \
-#    echo version 2 increment this line to invalidate cache of this layer while iterating build during development && \
-#    cargo build --release && \
-#    mkdir -p /usr/lib/janus/plugins && \
-#    mkdir -p /usr/lib/janus/events && \
-#    cp target/release/libjanus_plugin_sfu.so /usr/lib/janus/plugins && \
-#    cd / && rm -rf janus-plugin-sfu ~/.cargo
-
-# janus-plugin-sfu debug build:
-RUN git clone -b master https://github.com/networked-aframe/janus-plugin-sfu.git janus-plugin-sfu && \
+RUN git clone -b master https://github.com/networked-aframe/janus-plugin-sfu.git && \
     cd janus-plugin-sfu && \
     git checkout ${JANUS_SFU_COMMIT} && \
-    echo version 2 increment this line to invalidate cache of this layer while iterating build during development && \
-    curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y && \
-    . "$HOME/.cargo/env" && \
-    rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu && \
-    RUSTFLAGS=-Zsanitizer=address cargo build -Zbuild-std --target x86_64-unknown-linux-gnu && \
+    cargo build --release && \
     mkdir -p /usr/lib/janus/plugins && \
     mkdir -p /usr/lib/janus/events && \
-    cp target/x86_64-unknown-linux-gnu/debug/libjanus_plugin_sfu.so /usr/lib/janus/plugins && \
+    cp target/release/libjanus_plugin_sfu.so /usr/lib/janus/plugins && \
     cd / && rm -rf janus-plugin-sfu ~/.cargo
+
+# janus-plugin-sfu debug build:
+# RUN git clone -b master https://github.com/networked-aframe/janus-plugin-sfu.git janus-plugin-sfu && \
+#     cd janus-plugin-sfu && \
+#     git checkout ${JANUS_SFU_COMMIT} && \
+#     curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y && \
+#     . "$HOME/.cargo/env" && \
+#     rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu && \
+#     RUSTFLAGS=-Zsanitizer=address cargo build -Zbuild-std --target x86_64-unknown-linux-gnu && \
+#     mkdir -p /usr/lib/janus/plugins && \
+#     mkdir -p /usr/lib/janus/events && \
+#     cp target/x86_64-unknown-linux-gnu/debug/libjanus_plugin_sfu.so /usr/lib/janus/plugins && \
+#     cd / && rm -rf janus-plugin-sfu ~/.cargo
 
 COPY confs/* /usr/etc/janus/
 RUN chown -R nobody:nogroup /usr/etc/janus/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -99,7 +99,7 @@ RUN git clone -b 0.x https://github.com/meetecho/janus-gateway.git && \
     make && make install && make configs && \
     cd / && rm -rf janus-gateway
 
-ENV JANUS_SFU_COMMIT="d7bc08d4560a96c59f4ece2fa572e75c72288194"
+ENV JANUS_SFU_COMMIT="4226d0091b386576d221988c76e11c0d0ef7d215"
 # janus-plugin-sfu release build:
 #RUN git clone -b master https://github.com/networked-aframe/janus-plugin-sfu.git && \
 #    cd janus-plugin-sfu && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,7 +91,7 @@ RUN git clone -b 0.x https://github.com/meetecho/janus-gateway.git && \
 
 RUN git clone -b master https://github.com/networked-aframe/janus-plugin-sfu.git && \
     cd janus-plugin-sfu && \
-    git checkout 1914dfa7e22c793f4a684ebeb002304661270519 && \
+    git checkout d7bc08d4560a96c59f4ece2fa572e75c72288194 && \
     echo version 2 increment this line to invalidate cache of this layer while iterating build during development && \
     cargo build --release && \
     mkdir -p /usr/lib/janus/plugins && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,9 +89,11 @@ RUN git clone https://github.com/sctplab/usrsctp.git && \
 ENV JANUS_COMMIT="a7767ad30b803d96e11b491547bcf5660cb7a937"
 ENV JANUS_DEBUG_CFLAGS="-O1 -g -ggdb3 -fsanitize=address -fno-sanitize-recover=all -fsanitize-address-use-after-scope"
 ENV JANUS_DEBUG_LDFLAGS="-fsanitize=address"
+COPY g_list_free_pts.patch /
 RUN git clone -b 0.x https://github.com/meetecho/janus-gateway.git && \
     cd janus-gateway && \
     git checkout ${JANUS_COMMIT} && \
+    patch -p1 < ../g_list_free_pts.patch && \
     sh autogen.sh &&  \
     CFLAGS="${CFLAGS} ${JANUS_DEBUG_CFLAGS} -fno-omit-frame-pointer" LDFLAGS="${JANUS_DEBUG_LDFLAGS}" ./configure --prefix=/usr --disable-all-plugins --disable-all-handlers && \
     make && make install && make configs && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,20 +1,16 @@
-FROM ubuntu:24.04
-# If you want to build the docker image on Raspberry Pi OS (based on debian bullseye)
+ARG IMAGE=ubuntu:24.04
+FROM $IMAGE AS build
+# If you want to build the docker image on Raspberry Pi OS (based on debian bookworm)
 # and then copy the build artifacts on the host to run janus without docker,
-# comment "FROM ubuntu:20.04" and uncomment those two lines:
-# FROM debian:bullseye
-# RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
-# Installing rustup is needed to have a recent cargo version (1.61.0),
-# ubuntu:20.04 uses cargo 1.57.0 that is recent enough, but debian:bullseye uses cargo 1.46.0
-# that has an issue that produces the error "error inflating zlib stream; class=Zlib" when getting crate dependencies.
+# change the base image with docker build --build-arg="IMAGE=debian:bookworm"
 #
 # Look at the version used in
 # https://github.com/meetecho/janus-gateway/blob/master/.github/workflows/janus-ci.yml
 
-# For a debug build with libasan, add libasan8 to apt list, uncomment JANUS_DEBUG_CFLAGS and JANUS_DEBUG_LDFLAGS and use the janus-plugin-sfu debug instructions.
+# For a debug build with libasan, add libasan8 to apt list in the two phases, uncomment JANUS_DEBUG_CFLAGS and JANUS_DEBUG_LDFLAGS and use the janus-plugin-sfu debug instructions.
 # Run with:
 # docker run --net=host -e EVENT_LOOPS=4 -e MESSAGE_THREADS=1 janus:latest
-# to see the memory leaks on stdout when you ctrl+c the container if any. Using docker compose up don't show anything.
+# to see the memory leaks on stdout when you ctrl+c the container if any. Using docker compose up doesn't show anything.
 
 RUN apt-get -y update && DEBIAN_FRONTEND="noninteractive" TZ="Europe/Paris" apt-get install -y libmicrohttpd-dev \
     libjansson-dev \
@@ -123,6 +119,23 @@ RUN git clone -b master https://github.com/networked-aframe/janus-plugin-sfu.git
 #     mkdir -p /usr/lib/janus/events && \
 #     cp target/x86_64-unknown-linux-gnu/debug/libjanus_plugin_sfu.so /usr/lib/janus/plugins && \
 #     cd / && rm -rf janus-plugin-sfu ~/.cargo
+
+FROM $IMAGE
+RUN apt-get -y update && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+    libmicrohttpd12 \
+    libconfig9 \
+    libglib2.0-0 \
+    libjansson4 \
+#    libasan8 \
+    curl \
+    iproute2 && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=build /usr/lib/libwebsockets.so* /usr/lib/
+COPY --from=build /usr/lib/libsrtp2.so* /usr/lib/
+COPY --from=build /usr/lib/libnice.so* /usr/lib/
+COPY --from=build /usr/lib/libusrsctp.so* /usr/lib/
+COPY --from=build /usr/lib/janus /usr/lib/janus
+COPY --from=build /usr/bin/janus /usr/bin/janus
 
 COPY confs/* /usr/etc/janus/
 RUN chown -R nobody:nogroup /usr/etc/janus/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ FROM ubuntu:24.04
 # Look at the version used in
 # https://github.com/meetecho/janus-gateway/blob/master/.github/workflows/janus-ci.yml
 
-# For a debug build with libasan, remove cargo from apt list, add libasan8, uncomment JANUS_DEBUG_CFLAGS and JANUS_DEBUG_LDFLAGS and use the janus-plugin-sfu debug instructions.
+# For a debug build with libasan, add libasan8 to apt list, uncomment JANUS_DEBUG_CFLAGS and JANUS_DEBUG_LDFLAGS and use the janus-plugin-sfu debug instructions.
 # Run with:
 # docker run --net=host -e EVENT_LOOPS=4 -e MESSAGE_THREADS=1 janus:latest
 # to see the memory leaks on stdout when you ctrl+c the container if any. Using docker compose up don't show anything.
@@ -34,7 +34,6 @@ RUN apt-get -y update && DEBIAN_FRONTEND="noninteractive" TZ="Europe/Paris" apt-
     cmake \
     unzip \
     zip \
-    cargo \
 #    libasan8 \
     wget \
     curl \
@@ -104,6 +103,8 @@ ENV JANUS_SFU_COMMIT="4226d0091b386576d221988c76e11c0d0ef7d215"
 RUN git clone -b master https://github.com/networked-aframe/janus-plugin-sfu.git && \
     cd janus-plugin-sfu && \
     git checkout ${JANUS_SFU_COMMIT} && \
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal && \
+    . "$HOME/.cargo/env" && \
     cargo build --release && \
     mkdir -p /usr/lib/janus/plugins && \
     mkdir -p /usr/lib/janus/events && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 # If you want to build the docker image on Raspberry Pi OS (based on debian bullseye)
 # and then copy the build artifacts on the host to run janus without docker,
 # comment "FROM ubuntu:20.04" and uncomment those two lines:
@@ -7,6 +7,9 @@ FROM ubuntu:20.04
 # Installing rustup is needed to have a recent cargo version (1.61.0),
 # ubuntu:20.04 uses cargo 1.57.0 that is recent enough, but debian:bullseye uses cargo 1.46.0
 # that has an issue that produces the error "error inflating zlib stream; class=Zlib" when getting crate dependencies.
+#
+# Look at the version used in
+# https://github.com/meetecho/janus-gateway/blob/master/.github/workflows/janus-ci.yml
 
 RUN apt-get -y update && DEBIAN_FRONTEND="noninteractive" TZ="Europe/Paris" apt-get install -y libmicrohttpd-dev \
     libjansson-dev \
@@ -35,17 +38,17 @@ RUN apt-get -y update && DEBIAN_FRONTEND="noninteractive" TZ="Europe/Paris" apt-
     rm -rf /var/lib/apt/lists/*
 
 
-RUN LIBWEBSOCKET="4.3.2" && wget https://github.com/warmcat/libwebsockets/archive/v$LIBWEBSOCKET.tar.gz && \
+RUN LIBWEBSOCKET="4.3.3" && wget https://github.com/warmcat/libwebsockets/archive/v$LIBWEBSOCKET.tar.gz && \
     tar xzvf v$LIBWEBSOCKET.tar.gz && \
     cd libwebsockets-$LIBWEBSOCKET && \
     mkdir build && \
     cd build && \
-    cmake -DLWS_MAX_SMP=1 -DLWS_WITHOUT_EXTENSIONS=0 -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_C_FLAGS="-fpic" .. && \
+    cmake -DLWS_MAX_SMP=1 -DLWS_WITHOUT_EXTENSIONS=0 -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_C_FLAGS="-fpic" -DLWS_WITH_STATIC=OFF -DLWS_WITHOUT_CLIENT=ON -DLWS_WITHOUT_TESTAPPS=ON -DLWS_WITHOUT_TEST_SERVER=ON -DLWS_WITH_HTTP2=OFF .. && \
     make && make install && \
     cd / && rm -rf libwebsockets-$LIBWEBSOCKET
 
 
-RUN SRTP="2.4.2" && wget https://github.com/cisco/libsrtp/archive/v$SRTP.tar.gz && \
+RUN SRTP="2.6.0" && wget https://github.com/cisco/libsrtp/archive/v$SRTP.tar.gz && \
     tar xfv v$SRTP.tar.gz && \
     cd libsrtp-$SRTP && \
     ./configure --prefix=/usr --enable-openssl && \
@@ -53,33 +56,33 @@ RUN SRTP="2.4.2" && wget https://github.com/cisco/libsrtp/archive/v$SRTP.tar.gz 
     cd / && rm -rf libsrtp-$SRTP
 
 
-# libnice 2021-02-21 11:10 (post 0.1.18)
+# libnice 2020-07-06 13:53 (post 0.1.18)
 RUN git clone https://gitlab.freedesktop.org/libnice/libnice && \
 #    apt-get -y --no-install-recommends install ninja-build meson gtk-doc-tools libgnutls28-dev && \
 #    apt-get remove -y libnice-dev libnice10 && \
     cd libnice && \
-    git checkout 36aa468c4916cfccd4363f0e27af19f2aeae8604 && \
-    meson --prefix=/usr build && \
+    git checkout 48dac0d702b134f7b11b92602c234ba1120cc75b && \
+    meson setup -Dprefix=/usr -Dlibdir=lib -Ddebug=false -Doptimization=0 -Dexamples=disabled -Dgtk_doc=disabled -Dgupnp=disabled -Dgstreamer=disabled -Dtests=disabled build && \
     ninja -C build && \
     ninja -C build install && \
     cd / && rm -rf libnice
 
 
 # datachannel build
-# Jan 13, 2021 0.9.5.0 07f871bda23943c43c9e74cc54f25130459de830
+# Apr 17, 2024 master c4b52c34d4a7ecca6c992ba2f7f09607997d8ead
 RUN git clone https://github.com/sctplab/usrsctp.git && \
     cd usrsctp && \
-    git checkout 0.9.5.0 && \
+    git checkout c4b52c34d4a7ecca6c992ba2f7f09607997d8ead && \
     ./bootstrap && \
-    ./configure --prefix=/usr --disable-programs --disable-inet --disable-inet6 && \
+    ./configure --prefix=/usr --disable-static --disable-programs --disable-inet --disable-inet6 && \
     make && make install && \
     cd / && rm -rf usrsctp
 
 
-# 2022-10-21 15:02 7b6bcdcdbe02dd05932d778592f4c03604a83684 (post v0.13.0 from 0.x branch)
+# 2024-05-09 12:46 63ee713102f453447e3c912a7bb45791d4d198c5 (post v0.14.2 from 0.x branch)
 RUN git clone -b 0.x https://github.com/meetecho/janus-gateway.git && \
     cd janus-gateway && \
-    git checkout 7b6bcdcdbe02dd05932d778592f4c03604a83684 && \
+    git checkout a7767ad30b803d96e11b491547bcf5660cb7a937 && \
     sh autogen.sh &&  \
     CFLAGS="${CFLAGS} -fno-omit-frame-pointer" ./configure --prefix=/usr --disable-all-plugins --disable-all-handlers && \
     make && make install && make configs && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,11 @@ FROM ubuntu:24.04
 # Look at the version used in
 # https://github.com/meetecho/janus-gateway/blob/master/.github/workflows/janus-ci.yml
 
+# For a debug build with libasan, remove cargo from apt list, add libasan8, uncomment JANUS_DEBUG_CFLAGS and JANUS_DEBUG_LDFLAGS and use the janus-plugin-sfu debug intructions.
+# Run with:
+# docker run --net=host -e EVENT_LOOPS=4 -e MESSAGE_THREADS=1 janus:latest
+# to see the memory leaks on stdout when you ctrl+c the container if any. Using docker compose up don't show anything.
+
 RUN apt-get -y update && DEBIAN_FRONTEND="noninteractive" TZ="Europe/Paris" apt-get install -y libmicrohttpd-dev \
     libjansson-dev \
     libssl-dev \
@@ -29,7 +34,8 @@ RUN apt-get -y update && DEBIAN_FRONTEND="noninteractive" TZ="Europe/Paris" apt-
     cmake \
     unzip \
     zip \
-    cargo \
+#    cargo \
+    libasan8 \
     wget \
     curl \
     iproute2 && \
@@ -79,24 +85,42 @@ RUN git clone https://github.com/sctplab/usrsctp.git && \
     cd / && rm -rf usrsctp
 
 
-# 2024-05-09 12:46 63ee713102f453447e3c912a7bb45791d4d198c5 (post v0.14.2 from 0.x branch)
+# 2024-05-09 12:46 (post v0.14.2 from 0.x branch)
+ENV JANUS_COMMIT="a7767ad30b803d96e11b491547bcf5660cb7a937"
+ENV JANUS_DEBUG_CFLAGS="-O1 -g -ggdb3 -fsanitize=address -fno-sanitize-recover=all -fsanitize-address-use-after-scope"
+ENV JANUS_DEBUG_LDFLAGS="-fsanitize=address"
 RUN git clone -b 0.x https://github.com/meetecho/janus-gateway.git && \
     cd janus-gateway && \
-    git checkout a7767ad30b803d96e11b491547bcf5660cb7a937 && \
+    git checkout ${JANUS_COMMIT} && \
     sh autogen.sh &&  \
-    CFLAGS="${CFLAGS} -fno-omit-frame-pointer" ./configure --prefix=/usr --disable-all-plugins --disable-all-handlers && \
+    CFLAGS="${CFLAGS} ${JANUS_DEBUG_CFLAGS} -fno-omit-frame-pointer" LDFLAGS="${JANUS_DEBUG_LDFLAGS}" ./configure --prefix=/usr --disable-all-plugins --disable-all-handlers && \
     make && make install && make configs && \
     cd / && rm -rf janus-gateway
 
+ENV JANUS_SFU_COMMIT="d7bc08d4560a96c59f4ece2fa572e75c72288194"
+# janus-plugin-sfu release build:
+#RUN git clone -b master https://github.com/networked-aframe/janus-plugin-sfu.git && \
+#    cd janus-plugin-sfu && \
+#    git checkout ${JANUS_SFU_COMMIT} && \
+#    echo version 2 increment this line to invalidate cache of this layer while iterating build during development && \
+#    cargo build --release && \
+#    mkdir -p /usr/lib/janus/plugins && \
+#    mkdir -p /usr/lib/janus/events && \
+#    cp target/release/libjanus_plugin_sfu.so /usr/lib/janus/plugins && \
+#    cd / && rm -rf janus-plugin-sfu ~/.cargo
 
-RUN git clone -b master https://github.com/networked-aframe/janus-plugin-sfu.git && \
+# janus-plugin-sfu debug build:
+RUN git clone -b master https://github.com/networked-aframe/janus-plugin-sfu.git janus-plugin-sfu && \
     cd janus-plugin-sfu && \
-    git checkout d7bc08d4560a96c59f4ece2fa572e75c72288194 && \
+    git checkout ${JANUS_SFU_COMMIT} && \
     echo version 2 increment this line to invalidate cache of this layer while iterating build during development && \
-    cargo build --release && \
+    curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y && \
+    . "$HOME/.cargo/env" && \
+    rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu && \
+    RUSTFLAGS=-Zsanitizer=address cargo build -Zbuild-std --target x86_64-unknown-linux-gnu && \
     mkdir -p /usr/lib/janus/plugins && \
     mkdir -p /usr/lib/janus/events && \
-    cp target/release/libjanus_plugin_sfu.so /usr/lib/janus/plugins && \
+    cp target/x86_64-unknown-linux-gnu/debug/libjanus_plugin_sfu.so /usr/lib/janus/plugins && \
     cd / && rm -rf janus-plugin-sfu ~/.cargo
 
 COPY confs/* /usr/etc/janus/

--- a/docker/confs/janus.jcfg
+++ b/docker/confs/janus.jcfg
@@ -117,6 +117,19 @@ general: {
 									# only if allow_loop_indication is set to true;
 									# it's set to false by default to avoid abuses.
 									# Don't change if you don't know what you're doing!
+	#task_pool_size = 100			# By default, while the Janus core is single thread
+									# when it comes to processing incoming messages, it
+									# also uses a task pool with an indefinite amount
+									# of helper threads spawned on demand to handle
+									# messages addressed to plugins. If you want to
+									# limit this task pool size with a maximum number
+									# of concurrent threads, set the 'task_pool_size'
+									# property accordingly: a value of '0' means
+									# 'indefinite' and is the default. Notice that
+									# threads are automatically destroyed when unused
+									# for a while, so whatever value you choose simply
+									# puts a cap on the maximum concurrency.
+									# Don't change if you don't know what you're doing!
 	#opaqueid_in_api = true			# Opaque IDs set by applications are typically
 									# only passed to event handlers for correlation
 									# purposes, but not sent back to the user or
@@ -257,8 +270,11 @@ media: {
 # it should work in ICE-Lite mode (by default it doesn't). If libnice is
 # at least 0.1.15, you can choose which ICE nomination mode to use: valid
 # values are "regular" and "aggressive" (the default depends on the libnice
-# version itself; if we can set it, we set aggressive nomination). You can
-# also configure whether to use connectivity checks as keep-alives, which
+# version itself; if we can set it, we set aggressive nomination). If
+# libnice is at least 0.1.19, you can enable consent freshness checks for
+# PeerConnections as well: this will issue regular checks to check whether
+# or not the WebRTC peer isn't available anymore. Enabling consent freshness
+# will automatically also enable using connectivity checks as keep-alives, which
 # might help detecting when a peer is no longer available (notice that
 # current libnice master is breaking connections after 50 seconds when
 # keepalive-conncheck is being used, so if you want to use it, better
@@ -273,9 +289,18 @@ nat: {
 	nice_debug = false
 	#full_trickle = true
 	ice_nomination = "aggressive"
+	#ice_consent_freshness = true
 	ice_keepalive_conncheck = false
 	ice_lite = false
 	ice_tcp = false
+
+	# By default, Janus implements a grace period when detecting ICE
+	# failures in PeerConnections, to give time to applications to react
+	# to that, e.g., by enforcing an ICE restart. If you want an ICE
+	# failure to result in the PeerConnection being closed right away
+	# (e.g., with the help of consent freshness) then you can do that
+	# by uncommenting the following property and set it to true
+	#hangup_on_failed = true
 
 	# By default Janus tries to resolve mDNS (.local) candidates: even
 	# though this is now done asynchronously and shouldn't keep the API

--- a/docker/confs/janus.jcfg.sample
+++ b/docker/confs/janus.jcfg.sample
@@ -117,6 +117,19 @@ general: {
 									# only if allow_loop_indication is set to true;
 									# it's set to false by default to avoid abuses.
 									# Don't change if you don't know what you're doing!
+	#task_pool_size = 100			# By default, while the Janus core is single thread
+									# when it comes to processing incoming messages, it
+									# also uses a task pool with an indefinite amount
+									# of helper threads spawned on demand to handle
+									# messages addressed to plugins. If you want to
+									# limit this task pool size with a maximum number
+									# of concurrent threads, set the 'task_pool_size'
+									# property accordingly: a value of '0' means
+									# 'indefinite' and is the default. Notice that
+									# threads are automatically destroyed when unused
+									# for a while, so whatever value you choose simply
+									# puts a cap on the maximum concurrency.
+									# Don't change if you don't know what you're doing!
 	#opaqueid_in_api = true			# Opaque IDs set by applications are typically
 									# only passed to event handlers for correlation
 									# purposes, but not sent back to the user or
@@ -257,8 +270,11 @@ media: {
 # it should work in ICE-Lite mode (by default it doesn't). If libnice is
 # at least 0.1.15, you can choose which ICE nomination mode to use: valid
 # values are "regular" and "aggressive" (the default depends on the libnice
-# version itself; if we can set it, we set aggressive nomination). You can
-# also configure whether to use connectivity checks as keep-alives, which
+# version itself; if we can set it, we set aggressive nomination). If
+# libnice is at least 0.1.19, you can enable consent freshness checks for
+# PeerConnections as well: this will issue regular checks to check whether
+# or not the WebRTC peer isn't available anymore. Enabling consent freshness
+# will automatically also enable using connectivity checks as keep-alives, which
 # might help detecting when a peer is no longer available (notice that
 # current libnice master is breaking connections after 50 seconds when
 # keepalive-conncheck is being used, so if you want to use it, better
@@ -273,9 +289,18 @@ nat: {
 	nice_debug = false
 	#full_trickle = true
 	#ice_nomination = "regular"
+	#ice_consent_freshness = true
 	#ice_keepalive_conncheck = true
 	#ice_lite = true
 	#ice_tcp = true
+
+	# By default, Janus implements a grace period when detecting ICE
+	# failures in PeerConnections, to give time to applications to react
+	# to that, e.g., by enforcing an ICE restart. If you want an ICE
+	# failure to result in the PeerConnection being closed right away
+	# (e.g., with the help of consent freshness) then you can do that
+	# by uncommenting the following property and set it to true
+	#hangup_on_failed = true
 
 	# By default Janus tries to resolve mDNS (.local) candidates: even
 	# though this is now done asynchronously and shouldn't keep the API

--- a/docker/confs/janus.transport.http.jcfg
+++ b/docker/confs/janus.transport.http.jcfg
@@ -20,6 +20,8 @@ general: {
 	#secure_interface = "eth0"		# Whether we should bind this server to a specific interface only
 	#secure_ip = "192.168.0.1"		# Whether we should bind this server to a specific IP address (v4 or v6) only
 	#acl = "127.,192.168.0."		# Only allow requests coming from this comma separated list of addresses
+	#acl_forwarded = true			# Whether we should check the X-Forwarded-For header too for the ACL
+									# (default=false, since without a proxy in the middle this could be abused)
 	#mhd_connection_limit = 1020		# Open connections limit in libmicrohttpd (default=1020)
 	#mhd_debug = false					# Ask libmicrohttpd to write warning and error messages to stderr (default=false)
 }
@@ -46,6 +48,8 @@ admin: {
 	#admin_secure_interface = "eth0"	# Whether we should bind this server to a specific interface only
 	#admin_secure_ip = "192.168.0.1"	# Whether we should bind this server to a specific IP address (v4 or v6) only
 	#admin_acl = "127.,192.168.0."		# Only allow requests coming from this comma separated list of addresses
+	#admin_acl_forwarded = true			# Whether we should check the X-Forwarded-For header too for the admin ACL
+										# (default=false, since without a proxy in the middle this could be abused)
 }
 
 # The HTTP servers created in Janus support CORS out of the box, but by

--- a/docker/confs/janus.transport.http.jcfg.sample
+++ b/docker/confs/janus.transport.http.jcfg.sample
@@ -20,6 +20,8 @@ general: {
 	#secure_interface = "eth0"		# Whether we should bind this server to a specific interface only
 	#secure_ip = "192.168.0.1"		# Whether we should bind this server to a specific IP address (v4 or v6) only
 	#acl = "127.,192.168.0."		# Only allow requests coming from this comma separated list of addresses
+	#acl_forwarded = true			# Whether we should check the X-Forwarded-For header too for the ACL
+									# (default=false, since without a proxy in the middle this could be abused)
 	#mhd_connection_limit = 1020		# Open connections limit in libmicrohttpd (default=1020)
 	#mhd_debug = false					# Ask libmicrohttpd to write warning and error messages to stderr (default=false)
 }
@@ -44,8 +46,10 @@ admin: {
 	admin_https = false					# Whether to enable HTTPS (default=false)
 	#admin_secure_port = 7889			# Admin/monitor web server HTTPS port, if enabled
 	#admin_secure_interface = "eth0"	# Whether we should bind this server to a specific interface only
-	#admin_secure_ip = "192.168.0.1		# Whether we should bind this server to a specific IP address (v4 or v6) only
+	#admin_secure_ip = "192.168.0.1"	# Whether we should bind this server to a specific IP address (v4 or v6) only
 	#admin_acl = "127.,192.168.0."		# Only allow requests coming from this comma separated list of addresses
+	#admin_acl_forwarded = true			# Whether we should check the X-Forwarded-For header too for the admin ACL
+										# (default=false, since without a proxy in the middle this could be abused)
 }
 
 # The HTTP servers created in Janus support CORS out of the box, but by

--- a/docker/confs/janus.transport.websockets.jcfg
+++ b/docker/confs/janus.transport.websockets.jcfg
@@ -21,6 +21,8 @@ general: {
 									# to debug, supported values: err, warn, notice, info, debug, parser,
 									# header, ext, client, latency, user, count (plus 'none' and 'all')
 	#ws_acl = "127.,192.168.0."		# Only allow requests coming from this comma separated list of addresses
+	#ws_acl_forwarded = true		# Whether we should check the X-Forwarded-For header too for the ACL
+									# (default=false, since without a proxy in the middle this could be abused)
 }
 
 # If you want to expose the Admin API via WebSockets as well, you need to
@@ -39,6 +41,8 @@ admin: {
 	#admin_wss_ip = "192.168.0.1"		# Whether we should bind this server to a specific IP address only
 	#admin_wss_unix = "/run/awss.sock"	# Use WebSocket server over UNIX socket instead of TCP
 	#admin_ws_acl = "127.,192.168.0."	# Only allow requests coming from this comma separated list of addresses
+	#admin_ws_acl_forwarded = true		# Whether we should check the X-Forwarded-For header too for the ACL
+										# (default=false, since without a proxy in the middle this could be abused)
 }
 
 # The HTTP servers created in Janus support CORS out of the box, but by

--- a/docker/confs/janus.transport.websockets.jcfg.sample
+++ b/docker/confs/janus.transport.websockets.jcfg.sample
@@ -21,6 +21,8 @@ general: {
 									# to debug, supported values: err, warn, notice, info, debug, parser,
 									# header, ext, client, latency, user, count (plus 'none' and 'all')
 	#ws_acl = "127.,192.168.0."		# Only allow requests coming from this comma separated list of addresses
+	#ws_acl_forwarded = true		# Whether we should check the X-Forwarded-For header too for the ACL
+									# (default=false, since without a proxy in the middle this could be abused)
 }
 
 # If you want to expose the Admin API via WebSockets as well, you need to
@@ -39,6 +41,8 @@ admin: {
 	#admin_wss_ip = "192.168.0.1"		# Whether we should bind this server to a specific IP address only
 	#admin_wss_unix = "/run/awss.sock"	# Use WebSocket server over UNIX socket instead of TCP
 	#admin_ws_acl = "127.,192.168.0."	# Only allow requests coming from this comma separated list of addresses
+	#admin_ws_acl_forwarded = true		# Whether we should check the X-Forwarded-For header too for the ACL
+										# (default=false, since without a proxy in the middle this could be abused)
 }
 
 # The HTTP servers created in Janus support CORS out of the box, but by

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   janus:
     network_mode: host

--- a/docker/g_list_free_pts.patch
+++ b/docker/g_list_free_pts.patch
@@ -1,0 +1,46 @@
+diff --git a/sdp-utils.c b/sdp-utils.c
+index c06f3bbe..cf5a6f2a 100644
+--- a/sdp-utils.c
++++ b/sdp-utils.c
+@@ -736,6 +736,7 @@ int janus_sdp_get_codec_pt_full(janus_sdp *sdp, const char *codec, const char *p
+ 						pts = g_list_append(pts, GINT_TO_POINTER(pt));
+ 					} else {
+ 						/* Payload type for codec found */
++						g_list_free(pts);
+ 						return pt;
+ 					}
+ 				}
+@@ -761,6 +762,7 @@ int janus_sdp_get_codec_pt_full(janus_sdp *sdp, const char *codec, const char *p
+ 						if(strstr(a->value, profile_id) != NULL) {
+ 							/* Found */
+ 							JANUS_LOG(LOG_VERB, "VP9 profile %s found --> %d\n", profile, pt);
++							g_list_free(pts);
+ 							return pt;
+ 						}
+ 					} else if(h264 && strstr(a->value, "packetization-mode=0") == NULL) {
+@@ -772,6 +774,7 @@ int janus_sdp_get_codec_pt_full(janus_sdp *sdp, const char *codec, const char *p
+ 						if(strstr(a->value, profile_level_id) != NULL) {
+ 							/* Found */
+ 							JANUS_LOG(LOG_VERB, "H.264 profile %s found --> %d\n", profile, pt);
++							g_list_free(pts);
+ 							return pt;
+ 						}
+ 						/* Not found, try converting the profile to upper case */
+@@ -781,6 +784,7 @@ int janus_sdp_get_codec_pt_full(janus_sdp *sdp, const char *codec, const char *p
+ 						if(strstr(a->value, profile_level_id) != NULL) {
+ 							/* Found */
+ 							JANUS_LOG(LOG_VERB, "H.264 profile %s found --> %d\n", profile, pt);
++							g_list_free(pts);
+ 							return pt;
+ 						}
+ 					}
+@@ -788,8 +792,7 @@ int janus_sdp_get_codec_pt_full(janus_sdp *sdp, const char *codec, const char *p
+ 				ma = ma->next;
+ 			}
+ 		}
+-		if(pts != NULL)
+-			g_list_free(pts);
++		g_list_free(pts);
+ 		ml = ml->next;
+ 	}
+ 	return -1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -796,7 +796,7 @@ extern "C" fn handle_admin_message(_message: *mut RawJanssonValue) -> *mut RawJa
 
 static PLUGIN: Plugin = build_plugin!(
     LibraryMetadata {
-        api_version: 17,
+        api_version: 19,
         version: 1,
         name: c_str!("Janus SFU plugin"),
         package: c_str!("janus.plugin.sfu"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -714,7 +714,7 @@ fn push_response(from: &Session, txn: &TransactionId, body: &JsonValue, jsep: Op
     JanusError::from(push_event(
         from.as_ptr(),
         &PLUGIN as *const Plugin as *mut Plugin,
-        txn.0,
+        txn.as_ptr(),
         serde_to_jansson(body).as_mut_ref(),
         serde_to_jansson(&jsep).as_mut_ref(),
     ))
@@ -771,7 +771,7 @@ extern "C" fn handle_message(
         Ok(sess) => {
             let msg = RawMessage {
                 from: Arc::downgrade(&sess),
-                txn: TransactionId(transaction),
+                txn: unsafe { TransactionId::from_raw(transaction) },
                 msg: unsafe { JanssonValue::from_raw(message) },
                 jsep: unsafe { JanssonValue::from_raw(jsep) },
             };

--- a/src/txid.rs
+++ b/src/txid.rs
@@ -1,22 +1,42 @@
+use glib_sys as glib;
 use std::ffi::CStr;
 use std::fmt;
 use std::os::raw::c_char;
 
 /// A Janus transaction ID. Used to correlate signalling requests and responses.
 #[derive(Debug)]
-pub struct TransactionId(pub *mut c_char);
+pub struct TransactionId {
+    ptr: *mut c_char,
+}
+
+impl TransactionId {
+    /// Constructs a TransactionId from a pointer to a C string.
+    /// The string must be allocated with glibc (e.g., via g_strdup).
+    pub unsafe fn from_raw(ptr: *mut c_char) -> Self {
+        Self { ptr }
+    }
+    pub fn as_ptr(&self) -> *mut c_char {
+        self.ptr
+    }
+}
 
 unsafe impl Send for TransactionId {}
 
 impl fmt::Display for TransactionId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         unsafe {
-            if self.0.is_null() {
+            if self.ptr.is_null() {
                 f.write_str("<null>")
             } else {
-                let contents = CStr::from_ptr(self.0);
+                let contents = CStr::from_ptr(self.ptr);
                 f.write_str(&contents.to_string_lossy())
             }
         }
+    }
+}
+
+impl Drop for TransactionId {
+    fn drop(&mut self) {
+        unsafe { glib::g_free(self.ptr as *mut _) }
     }
 }


### PR DESCRIPTION
Update docker image to ubuntu:24.04, libwebsockets 4.3.3, libsrtp 2.6.0, libnice, usrsctp master, janus-gateway v0.14.2+

Refs https://github.com/networked-aframe/naf-janus-adapter/issues/62