### PR TITLE
Fix ALLOW_LOOP_INDICATION variable that didn't work

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 ADMIN_SECRET=${ADMIN_SECRET:-janusoverlord}
 DEBUG_LEVEL=${DEBUG_LEVEL:-4}
@@ -52,7 +53,7 @@ fi
 if [ ! -z "$ALLOW_LOOP_INDICATION" ]; then
     sed -i \
         -e "s|#allow_loop_indication =.*|allow_loop_indication = ${ALLOW_LOOP_INDICATION}|" \
-        /usr/etc/janus/janus.cfg
+        /usr/etc/janus/janus.jcfg
 fi
 
 MAX_ROOM_SIZE=${MAX_ROOM_SIZE:-30}


### PR DESCRIPTION
with `.env`:
```
EVENT_LOOPS=4                                                                      
ALLOW_LOOP_INDICATION=true
```

```
docker compose exec -it janus bash
cat ./usr/etc/janus/janus.jcfg |grep loop
        event_loops = 4
        #allow_loop_indication = true
```
so the `ALLOW_LOOP_INDICATION` had no effect.
This wasn't properly verified when #7 was done.

The config filename was wrong janus.cfg instead of janus.jcfg.

I added the `set -e` flag to properly log an error if a command fail, for any future contribution.
```
janus-1  | sed: can't read /usr/etc/janus/janus.cfg: No such file or directory
janus-1 exited with code 2
```

and I fixed the filename of course.