### PR TITLE
Remove once_cell dependency in favor of new built-in OnceLock and LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,6 @@ dependencies = [
  "janus-plugin",
  "jsonwebtoken",
  "num_cpus",
- "once_cell",
  "rust-ini",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ lto = true
 [dependencies]
 glib-sys = "0.19"
 janus-plugin = "0.13"
-once_cell = "1.19"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rust-ini = "0.13"

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1,10 +1,9 @@
 use crate::messages::{RoomId, Subscription, UserId};
 use janus_plugin::sdp::Sdp;
 use janus_plugin::session::SessionWrapper;
-use once_cell::sync::OnceCell;
 /// Types for representing Janus session state.
 use std::sync::atomic::{AtomicBool, AtomicIsize};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 /// Once they join a room, all sessions are classified as either subscribers or publishers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -42,13 +41,13 @@ pub struct SessionState {
     pub fir_seq: AtomicIsize,
 
     /// Information pertaining to this session's user and room, if joined.
-    pub join_state: OnceCell<JoinState>,
+    pub join_state: OnceLock<JoinState>,
 
     // todo: these following fields should be unified with the JoinState, but it's
     // annoying in practice because they are established during JSEP negotiation
     // rather than during the join flow
     /// If this is a subscriber, the subscription this user has established, if any.
-    pub subscription: OnceCell<Subscription>,
+    pub subscription: OnceLock<Subscription>,
 
     /// If this is a publisher, the offer for subscribing to it.
     pub subscriber_offer: Arc<Mutex<Option<Sdp>>>,


### PR DESCRIPTION
Replace `once_cell::sync::OnceCell` by built-in `OnceLock` https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#oncecell-and-oncelock and `once_cell::sync::Lazy` by built-in `LazyLock` (https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html)
This requires rust 1.80.
